### PR TITLE
fix(archive-first): narrow PreToolUse Bash hook regex to word boundaries (#32)

### DIFF
--- a/plugins/archive-first/.claude-plugin/plugin.json
+++ b/plugins/archive-first/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "archive-first",
   "description": "Protect files from AI-assisted deletion with the Archive-First strategy. PreToolUse hooks block destructive commands on archived/ paths. Toggle protection with archived-lock/archived-unlock.",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "author": {
     "name": "Che Cheng"
   }

--- a/plugins/archive-first/CHANGELOG.md
+++ b/plugins/archive-first/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.1] - 2026-05-07
+
+### Fixed
+- PreToolUse Bash hook regex narrowed to word boundaries (`grep -wE`) for both `(rm|rmdir|unlink)` and `archived` matches. Previously over-broad substring grep fired false-positives on commands containing `platform` / `format` / `perform` / `transform` / `inform` / `harm` (any English word with `rm` substring) when the same command also mentioned `archived` anywhere — common in `gh issue comment` heredoc bodies discussing archive governance. Resolves #32.
+
 ## [2.1.0] - (date unknown — please fill in)
 
 ### Changed

--- a/plugins/archive-first/hooks/hooks.json
+++ b/plugins/archive-first/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ -f ~/.cache/archive-first/disabled ] && exit 0; COMMAND=$(jq -r '.tool_input.command // empty'); if echo \"$COMMAND\" | tr ';' '\\n' | sed 's/&&/\\n/g' | sed 's/||/\\n/g' | grep -E '(rm|rmdir|unlink)' | grep -qE 'archived'; then jq -n '{hookSpecificOutput:{hookEventName:\"PreToolUse\",permissionDecision:\"deny\",permissionDecisionReason:\"Blocked: destructive command targeting archived/ directory. Use /archive-first:archived-unlock to disable protection first.\"}}'; else exit 0; fi"
+            "command": "[ -f ~/.cache/archive-first/disabled ] && exit 0; COMMAND=$(jq -r '.tool_input.command // empty'); if echo \"$COMMAND\" | tr ';' '\\n' | sed 's/&&/\\n/g' | sed 's/||/\\n/g' | grep -wE '(rm|rmdir|unlink)' | grep -qwE 'archived'; then jq -n '{hookSpecificOutput:{hookEventName:\"PreToolUse\",permissionDecision:\"deny\",permissionDecisionReason:\"Blocked: destructive command targeting archived/ directory. Use /archive-first:archived-unlock to disable protection first.\"}}'; else exit 0; fi"
           }
         ]
       },


### PR DESCRIPTION
Refs #32

## Summary

PreToolUse Bash hook 的 regex 從 substring match 改為 word-boundary match (`grep -wE`),修掉 #32 報告的 false-positive：commands containing English words with the destructive-token substring (e.g. `platform`, `format`, `perform`) that also mention `archived` anywhere were getting blocked despite being non-destructive.

## Dogfood evidence

開立此 PR 過程本身踩到 bug 兩次:
1. 第一次 `gh issue comment` 試 post Implementation Plan body — body 含「`platform`」(舉例) + 「`archived`」(描述目錄) → blocked
2. `git commit -m "..."` 用 `-m` flag passing message — message 含 `rm` 拼字 + `archived` → blocked

兩次都用 `--body-file` / `-F` workaround 繞過。Workaround 本身也是 #32 用 issue body 列的「current friction」。

## Acceptance test results

10/10 test cases pass with new regex:

| Old | New | Expected | Case |
|-----|-----|----------|------|
| BLOCK | PASS | PASS | prose with platform+archived |
| BLOCK | BLOCK | BLOCK | rm -rf archived/ |
| PASS  | PASS | PASS | cd archived && rm sibling |
| BLOCK | BLOCK | BLOCK | rm /path/to/archived/foo |
| PASS  | PASS | PASS | mv archived old_archived |
| BLOCK | PASS | PASS | rm archived_logs.txt (file with prefix) |
| PASS  | PASS | PASS | prose mentioning platform alone |
| BLOCK | PASS | PASS | format word + archived prose |
| BLOCK | BLOCK | BLOCK | rmdir archived/ |
| BLOCK | BLOCK | BLOCK | unlink archived/foo |

3 prior false-positives now correctly pass; all 4 actual destructive cases still block. Test script: `/tmp/test-archive-first-fix.sh` (gist below).

## Checklist
- [x] Diagnose (#32 was diagnosed in issue body — RCA + suggested fix included)
- [x] Implement (1 commit, 3 files changed)
- [x] Verify (10/10 acceptance test cases)
- [ ] **Pending: human review of this PR + /idd-close after merge**

## Files Changed
- `plugins/archive-first/hooks/hooks.json` — regex narrowed
- `plugins/archive-first/.claude-plugin/plugin.json` — 2.1.0 → 2.1.1
- `plugins/archive-first/CHANGELOG.md` — Fixed entry under [2.1.1]

---
Generated by /idd-implement on PR path. **Do NOT add 'Closes #32'** — IDD discipline requires manual /idd-close after merge to enforce checklist gate + closing summary.
