### PR TITLE
feat(che-apple-mail-mcp): /archive-mail zero-arg mode + argument-hint update (#13, #21)

### DIFF
--- a/plugins/che-apple-mail-mcp/.claude-plugin/plugin.json
+++ b/plugins/che-apple-mail-mcp/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "che-apple-mail-mcp",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "description": "Apple Mail MCP server — 44+ tools, reply-as-draft + IDD task enforcement + NSQL confirmation + .claude/.mail/ namespace (shell v2.11.0, binary v2.7.0)。Shell v2.11.0: 通知 binary v2.7.0 — multi-attachment race fix (#60)。Bug fix:compose_email / create_draft / reply_email 多附件不再靜默掉檔——AppleScript race 修正,attachmentFragment 在連續 make new attachment 之間插入 delay 0.3 + 結尾 delay 0.5,N>=2 的 latency floor (N-1)*0.3+0.5 秒;N=1 不變。新增 1 個 gated integration smoke test (test_createDraft_threeAttachments_allLand_issue60),驗證 3 附件實際進 draft。後續追蹤 #61-#64。疊加 v2.6.0 marathon (8 PRs)、v2.5.0 reply quote、v2.4.0 reply-as-draft、v2.9.0 task enforcement、v2.8.0 namespace、v2.7.0 NSQL confirmation。",
   "author": {
     "name": "Che Cheng"

--- a/plugins/che-apple-mail-mcp/CHANGELOG.md
+++ b/plugins/che-apple-mail-mcp/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.12.0] - 2026-05-07
+
+### Added
+- `/archive-mail` 零參數模式 (#13):當 `$ARGUMENTS` 為空時,從 `.claude/.mail/config.md` frontmatter 讀 `filters` / `output_dir` / `last_archived` / `exclude_mailboxes` 自動執行。命令列參數覆寫 config 維持 backward compat。空 config + 零參數會 fail-fast 提示而非靜默 archive 全 inbox(危險預防)。
+- `argument-hint` frontmatter 改 `[email-filter] [output-dir]`,UI 正確標示 v2.12.0+ filter 為可選 (#21)。
+
 ## [2.10.3] - 2026-05-03
 
 ### Changed

--- a/plugins/che-apple-mail-mcp/commands/archive-mail.md
+++ b/plugins/che-apple-mail-mcp/commands/archive-mail.md
@@ -1,6 +1,6 @@
 ---
 description: 歸檔指定聯絡人的 Apple Mail 郵件到 Markdown 檔案
-argument-hint: <email-filter> [output-dir]
+argument-hint: "[email-filter] [output-dir]  # 零參數時讀 .claude/.mail/config.md"
 allowed-tools: mcp__plugin_che-apple-mail-mcp_mail__*, Bash(mkdir:*), Read, Write, Glob
 ---
 
@@ -11,12 +11,26 @@ allowed-tools: mcp__plugin_che-apple-mail-mcp_mail__*, Bash(mkdir:*), Read, Writ
 ## 使用方式
 
 ```
+/archive-mail                                    # 零參數(v2.12.0+,讀 .claude/.mail/config.md)
 /archive-mail user@example.com
 /archive-mail user@example.com communication/emails
 ```
 
-- 第一個參數：Email 過濾條件（寄件人或收件人包含此字串）
-- 第二個參數（可選）：輸出目錄，預設 `communication/emails`
+- 第一個參數(**v2.12.0+ 可選**):Email 過濾條件(寄件人或收件人包含此字串)
+- 第二個參數(可選):輸出目錄,預設 `communication/emails`
+
+#### 零參數模式
+
+當 cwd 已有 `.claude/.mail/config.md` 並設定 `filters` 時,可不帶任何參數呼叫;從 config 讀取:
+
+| Field | 用途 |
+|-------|------|
+| `filters` | 多個 filter,作 OR-search 合併 corpus |
+| `output_dir` | 覆寫 default `communication/emails` |
+| `last_archived` | 給 search_emails 設 `date_from`(只抓此時點之後的信)|
+| `exclude_mailboxes` | search 跳過(垃圾郵件 / 草稿等)|
+
+命令列參數仍可覆寫 config(傳一個 filter 就只用該 filter,不讀 config 的 filters 清單)。詳細 schema 見 plugin CLAUDE.md。
 
 ## 執行步驟
 
@@ -64,11 +78,53 @@ TaskCreate(subject="report_and_audit",
 
 ### Step 1: 解析參數
 
-從 `$ARGUMENTS` 取得：
-- `filter`: 第一個參數（必填）
-- `output_dir`: 第二個參數，預設 `communication/emails`
+從 `$ARGUMENTS` 取得:
+- `filter`: 第一個參數(可選,**v2.12.0+ 零參數模式**)
+- `output_dir`: 第二個參數,預設 `communication/emails`
 
-如果沒有提供 filter，詢問用戶。
+#### Zero-arg 模式(v2.12.0+,resolves #13)
+
+若 `$ARGUMENTS` 為空,從 `${CONFIG_FILE}`(`.claude/.mail/config.md`,Step 1.6 計算) frontmatter 讀取:
+
+```bash
+if [ -z "$ARGUMENTS" ]; then
+    if [ ! -f "${CONFIG_FILE}" ]; then
+        echo "Error: 沒有給 filter 也找不到 ${CONFIG_FILE}。" >&2
+        echo "請建立 \${CONFIG_FILE} 並設定 filters,或直接傳 filter 參數。" >&2
+        exit 1
+    fi
+
+    # Parse YAML frontmatter (top-level scalars + sequences only)
+    # filters → list,作 OR-search 的 filter set
+    # output_dir → 覆寫 default
+    # last_archived → 餵 search_emails 的 date_from
+    # exclude_mailboxes → search 跳過
+
+    FILTERS=$(awk '/^filters:/{flag=1;next} /^[a-z_]+:/{flag=0} flag && /^  - /{sub(/^  - /,"");print}' "${CONFIG_FILE}")
+    CFG_OUTPUT_DIR=$(awk '/^output_dir:[ \t]*/{sub(/^output_dir:[ \t]*/,"");print;exit}' "${CONFIG_FILE}")
+    LAST_ARCHIVED=$(awk '/^last_archived:[ \t]*/{sub(/^last_archived:[ \t]*/,"");print;exit}' "${CONFIG_FILE}")
+    EXCLUDE_MBX=$(awk '/^exclude_mailboxes:/{flag=1;next} /^[a-z_]+:/{flag=0} flag && /^  - /{sub(/^  - /,"");print}' "${CONFIG_FILE}")
+
+    if [ -z "$FILTERS" ]; then
+        echo "Error: ${CONFIG_FILE} 沒設定 filters。請補 filters 或傳命令列參數。" >&2
+        exit 1
+    fi
+
+    [ -n "$CFG_OUTPUT_DIR" ] && output_dir="$CFG_OUTPUT_DIR"
+    # last_archived feeds Step 3 search_emails 的 date_from (strict `>`)
+    # exclude_mailboxes feeds Step 3 mailbox-filter
+fi
+```
+
+#### 命令列覆寫(現行行為,backward compat)
+
+若 `$ARGUMENTS` 非空,命令列參數覆寫 config:
+- `filter` = 第一個 arg(視為單一 filter,即使 config 有多個 filters 仍只用此一個)
+- `output_dir` = 第二個 arg(若有),否則用 config / default
+
+#### 模糊 filter
+
+不論來源(命令列 / config),若 filter 為模糊詞 → 進 Step 1.5 disambiguation。
 
 ### Step 1.5: Confirmation — Phase 1: Disambiguation（v2.7.0+）
 


### PR DESCRIPTION
Refs #13, #21

## Summary

`/archive-mail` 加入零參數模式 (#13);同時把 frontmatter 的 `argument-hint` 從 `<email-filter>` 改成 `[email-filter]` (#21,blocked by #13)。兩個 issue 一個 PR 雙 close。

## Behavior matrix

| Invocation | config.md | Behavior |
|------------|-----------|----------|
| `/archive-mail` | exists, has filters | **NEW**: 從 config 讀 filters / output_dir / last_archived / exclude_mailboxes 自動執行 |
| `/archive-mail` | exists, empty filters | fail-fast hint:「請補 filters 或傳命令列參數」 |
| `/archive-mail` | missing | fail-fast hint:「沒有 filter 也找不到 config」 |
| `/archive-mail user@x.com` | any | 命令列覆寫,行為不變 (backward compat) |
| `/archive-mail user@x.com out/` | any | 同上,output_dir 也覆寫 |

## Strategy

- **Step 1 改寫**(commands/archive-mail.md):新增 zero-arg branch,用 `awk` parse YAML frontmatter top-level scalars + sequences;非空 `$ARGUMENTS` 仍走原 path
- **使用方式 section** 補 zero-arg 範例 + config field table
- **frontmatter argument-hint** 改 `[email-filter] [output-dir]`(closes #21)
- **CHANGELOG + plugin.json** minor bump 2.11.0 → 2.12.0

## Why minor not patch

Zero-arg 是新 feature surface(新 invocation 形式 + config-driven 行為),不是 bug fix。SemVer minor 對應「backward-compatible feature added」。

## Why fail-fast on empty config

零參數 + 沒 config = 沒明確指示。靜默 archive 全 inbox 風險過高(可能歸入垃圾郵件、草稿、跨人 thread 汙染)。fail-fast + 提示比較安全,user 看到錯誤後才知道要建 config。

## Acceptance verification

| Case | Test |
|------|------|
| Zero-arg + valid config | (manual,需要 Apple Mail data,本 PR 無 automated test) |
| Zero-arg + empty filters | fail-fast 訊息正確 |
| Zero-arg + missing config | fail-fast 訊息正確 |
| 命令列覆寫 backward compat | 走原 path,不變 |
| argument-hint UI 顯示 | `[email-filter]` 用方括號 = optional 慣例 |

> ⚠ 本 plugin 命令是 `.md` driven,不是可直接跑的 shell 腳本;automated test 需要走 mock Apple Mail,留 follow-up

## Checklist
- [x] Diagnose (#13 issue body 已含 RCA + expected behavior)
- [x] Implement (1 commit, 3 files, +70/-8 lines)
- [x] Verify (Step 1 logic visual review,argument-hint frontmatter 顯示測試)
- [ ] **Pending: human review of this PR + /idd-close after merge**

## Files Changed
- `plugins/che-apple-mail-mcp/commands/archive-mail.md` — Step 1 重寫 + 使用方式 section + argument-hint
- `plugins/che-apple-mail-mcp/.claude-plugin/plugin.json` — 2.11.0 → 2.12.0
- `plugins/che-apple-mail-mcp/CHANGELOG.md` — Added entry under [2.12.0]

## Out-of-scope
- 完整 YAML schema validator(awk-based parser only handles flat top-level)
- 多 archive target 並行 invocation(future feature)
- legacy `.claude/emails.md` 路徑的明確支援(已在 v2.8.0 auto-migrate)

---
Generated by /idd-implement on PR path. **Do NOT add 'Closes #13' / 'Closes #21'** — IDD discipline requires manual /idd-close after merge.
