### PR TITLE
refactor(che-apple-mail-mcp): /archive-mail markdown template default simplified (#17)

### DIFF
--- a/plugins/che-apple-mail-mcp/.claude-plugin/plugin.json
+++ b/plugins/che-apple-mail-mcp/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "che-apple-mail-mcp",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "description": "Apple Mail MCP server — 44+ tools, reply-as-draft + IDD task enforcement + NSQL confirmation + .claude/.mail/ namespace (shell v2.11.0, binary v2.7.0)。Shell v2.11.0: 通知 binary v2.7.0 — multi-attachment race fix (#60)。Bug fix:compose_email / create_draft / reply_email 多附件不再靜默掉檔——AppleScript race 修正,attachmentFragment 在連續 make new attachment 之間插入 delay 0.3 + 結尾 delay 0.5,N>=2 的 latency floor (N-1)*0.3+0.5 秒;N=1 不變。新增 1 個 gated integration smoke test (test_createDraft_threeAttachments_allLand_issue60),驗證 3 附件實際進 draft。後續追蹤 #61-#64。疊加 v2.6.0 marathon (8 PRs)、v2.5.0 reply quote、v2.4.0 reply-as-draft、v2.9.0 task enforcement、v2.8.0 namespace、v2.7.0 NSQL confirmation。",
   "author": {
     "name": "Che Cheng"

--- a/plugins/che-apple-mail-mcp/CHANGELOG.md
+++ b/plugins/che-apple-mail-mcp/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.13.0] - 2026-05-07
+
+### Changed
+- **BEHAVIOR CHANGE — `/archive-mail` Step 5 markdown template default simplified (#17)**: previously every archived email got a 4-section template (元數據表 + 信件內容 + 重點摘要 + 待辦事項). Real-world usage (tatsuma project, 50 historical archives) showed the elaborate sections are unused noise — AI summaries are unreliable and require manual review, breaking batch processing consistency. Default is now a simple template (frontmatter + 4-line `Subject/From/To/Date` header + body), matching the historical convention. Existing archives are NOT reprocessed (Message-ID dedup prevents). Users wanting the old elaborate template can opt in via `.claude/.mail/config.md` frontmatter `enrichment: summary+todos`.
+- Plugin version bumped 2.12.0 → 2.13.0 (after #13 PR #39 landed at 2.12.0). Frontmatter still includes all 6 fields (`message_id` / `thread_key` / `in_reply_to` / `date` / `sender` / `direction`) — thread index reconstruction depends on these.
+
+### Added
+- `enrichment` field to `.claude/.mail/config.md` schema. Values: `none` (default, simple template) | `summary+todos` (4-section enriched template). Documented in plugin CLAUDE.md.
+
 ## [2.12.0] - 2026-05-07
 
 ### Added

--- a/plugins/che-apple-mail-mcp/CLAUDE.md
+++ b/plugins/che-apple-mail-mcp/CLAUDE.md
@@ -172,6 +172,8 @@ participant_aliases:               # 模糊人名 → 標準 email 對應表
 subject_keywords_strict: true      # bool, default false。true = subject-only match 不算 hit;
                                    # 防止「履歷」這種 generic 關鍵字汙染 result
 
+enrichment: none                   # v2.13.0+: 'none'(預設,簡單 template) | 'summary+todos'(AI 摘要 + 待辦)
+
 output_dir: communications/emails  # string,default "communications/emails"。
                                    # archive markdown 寫入路徑(相對 cwd)
 

--- a/plugins/che-apple-mail-mcp/commands/archive-mail.md
+++ b/plugins/che-apple-mail-mcp/commands/archive-mail.md
@@ -416,7 +416,41 @@ Subject → filename 轉換規則（依此順序執行）：
 
 > **歷史相容 note**：`communications/` 有少量 `-a` / `-b` 字母後綴（如 `2024-07-14_...-a.md`）。新規不遷移舊檔，但新檔**一律用 `-1` `-2` `-3` 數字後綴**。若混用造成困擾，另開 follow-up issue。
 
-**內容格式**（v2.6.0+：加入 YAML frontmatter，便於 thread 索引重建）：
+**內容格式**(v2.13.0+ 預設簡化,issue #17;v2.6.0+ 加入 YAML frontmatter):
+
+預設使用 **simple template**(對應 tatsuma 50 個既有檔案格式)。若 `${CONFIG_FILE}` 設 `enrichment: summary+todos`,改用下方 **enriched template** 加上 AI 摘要 + 待辦兩段。
+
+```bash
+# Step 1.6 階段已 parse;此處使用
+ENRICHMENT=$(awk '/^enrichment:[ \t]*/{sub(/^enrichment:[ \t]*/,"");print;exit}' "${CONFIG_FILE}" 2>/dev/null)
+ENRICHMENT="${ENRICHMENT:-none}"  # default: simple template (v2.13.0+)
+```
+
+#### Simple template (default, v2.13.0+):
+
+```markdown
+---
+message_id: "<9c7a43db76e94a64a51f85d04c3bf01b@ntu.edu.tw>"
+thread_key: "SE manuscript 10xx-2025"
+in_reply_to: "<eddba65d53754587aeee5d86ff631d2c@ntu.edu.tw>"
+date: 2026-01-28T08:35:34Z
+sender: yfhsu@ntu.edu.tw
+direction: received
+---
+
+Subject: <subject>
+From: <sender display name OR email>
+To: <recipient(s)>
+Date: YYYY-MM-DD HH:MM
+
+[完整 body]
+```
+
+Frontmatter 保留全部 6 欄位(thread index 重建仍依賴);header 改為 4 行純文字 `Subject/From/To/Date`,直接接 body,不再有元數據表 / 重點摘要 / 待辦事項三段。
+
+#### Enriched template (opt-in via `enrichment: summary+todos`):
+
+僅在 `${CONFIG_FILE}` 設定後觸發。Schema:
 
 ```markdown
 ---


### PR DESCRIPTION
Refs #17

## Summary

`/archive-mail` Step 5 markdown template 預設改為 **simple format**(對應 tatsuma 50 個既有歷史檔的格式),原 4-section enriched template (元數據表 + 摘要 + 待辦) 改為 opt-in via `.claude/.mail/config.md` `enrichment: summary+todos`。

## Behavior matrix

| config | Step 5 output |
|--------|--------------|
| `enrichment: none` (default) **or** missing | Simple: frontmatter + `Subject/From/To/Date` 4-行 header + body |
| `enrichment: summary+todos` | Enriched: frontmatter + 元數據表 + 信件內容 + 重點摘要 + 待辦事項 |

## Why this matters

issue #17 來自 tatsuma 專案實戰觀察:
- 50 個既有歸檔全部是 simple format (沒人用 enriched)
- AI 摘要 + 待辦事項常誤判,反而 require 人工檢閱
- 批次處理一致性被破壞 (有些有 summary、有些沒)
- 每封多兩段 AI 生成 → 歸檔時間拉長

預設值改 simple = sensible default。需要 enriched 的 user 一行 config 即可拿回。

## Why minor not major

雖然 default 改變,但:
- 既有歸檔檔案不會被 reprocess (Message-ID dedup 阻止)
- Enriched 仍可拿回 (一行 config)
- SemVer 對「default behavior change with backward-compat path」是 minor

但 CHANGELOG 明標 「BEHAVIOR CHANGE」,help maintainers + downstream tooling 識別。

## Version overlap with #13 PR #39

本 PR 從 main 分,版本跳 2.11 → 2.13。#13 PR #39 (零參數模式) 在 idd/13-zero-arg-archive-mail 用 2.12.0。Maintainer 在 merge 時:
- #13 先 merge → main 變 2.12.0 → 本 PR rebase → 仍 2.13.0 (順序自然)
- #17 先 merge → main 變 2.13.0 → #13 需要 rebase 改 2.13.1 (downgrade)

建議 #13 先 merge (feature add),#17 後 merge (default change)。

## Acceptance verification

| Case | Test |
|------|------|
| Default config (no enrichment) | Step 5 走 simple branch |
| `enrichment: none` 顯式設定 | Step 5 走 simple branch (同 default) |
| `enrichment: summary+todos` | Step 5 走 enriched branch (4-section) |
| 既有歸檔 (enriched format) | 不 reprocess (dedup 阻止) |
| Frontmatter 6 fields | 兩種 template 都保留 |

> ⚠ 本 plugin 命令是 `.md` driven,automated test 需要走 mock Apple Mail。本 PR 純 spec change,visual review verified。

## Checklist
- [x] Diagnose (#17 issue body 已含 RCA + expected behavior with config flag)
- [x] Implement (1 commit, 4 files, +46/-2 lines)
- [x] Verify (Step 5 spec visual review,config schema 對齊 #19 CLAUDE.md)
- [ ] **Pending: human review of this PR + /idd-close after merge**

## Files Changed
- `plugins/che-apple-mail-mcp/commands/archive-mail.md` — Step 5 template 重寫 (simple default + enriched opt-in)
- `plugins/che-apple-mail-mcp/CLAUDE.md` — schema 加 `enrichment` field
- `plugins/che-apple-mail-mcp/.claude-plugin/plugin.json` — 2.11.0 → 2.13.0
- `plugins/che-apple-mail-mcp/CHANGELOG.md` — Changed entry under [2.13.0] with BEHAVIOR CHANGE banner

## Out-of-scope
- 既有 enriched 檔批次 downgrade (沒人要)
- 命令列 `--enrichment` flag (config-only,future enhancement)
- AI 摘要 quality 改善

---
Generated by /idd-implement on PR path. **Do NOT add 'Closes #17'** — IDD discipline requires manual /idd-close after merge.
