### PR TITLE
cluster: 4 docs follow-ups from #49 / #60 IDD lifecycles

### DIFF
--- a/plugins/che-apple-mail-mcp/CHANGELOG.md
+++ b/plugins/che-apple-mail-mcp/CHANGELOG.md
@@ -44,12 +44,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.16.1] - 2026-05-09
 
 ### Notes
-- **Bump-only release** to ship binary v2.7.1 + catch up tool count drift in user-facing surfaces (44 → 47)。Shell 邏輯 v2.16.0 不變,本版本只更新 wrapper 拉取的 binary tag。Backfilled per **#52** (sister concern from #49) — original v2.16.1 commit `8089765` 漏寫此 entry,KAC invariant 要求 every released version 有 entry。
+- **Bump-only release** to ship binary v2.7.1 + catch up tool count drift in `plugin.json` / `marketplace.json` descriptions (44 → 47)。Shell 邏輯 v2.16.0 不變,本版本只更新 wrapper 拉取的 binary tag。Backfilled per **#52** (sister concern from #49) — original v2.16.1 commit `8089765` 漏寫此 entry,KAC invariant 要求 every released version 有 entry。
 - Binary v2.7.1 ships:
   - **#72** base64 decoding fix — attachments with unusual MIME encoding now save correctly
   - **#69** SQLite fast-path stderr logging — silent fallback to AppleScript path now visible in logs
   - **#66** `.partial.emlx` attachment fix — incomplete download artifacts no longer crash get_email parsing
-- Tool count drift catch-up (44 → 47): per `tool-readme-sync` audit pattern, README + plugin.json description + marketplace.json description align on the actual tool count exposed by binary v2.7.1.
+- Tool count drift catch-up (44 → 47): commit `8089765` 只 touched `plugin.json` + `marketplace.json` description fields(README 未變動)。per `tool-readme-sync` audit pattern,後續 release 應補做 README 同步檢查。
 
 ## [2.16.0] - 2026-05-07
 

--- a/plugins/che-apple-mail-mcp/CHANGELOG.md
+++ b/plugins/che-apple-mail-mcp/CHANGELOG.md
@@ -41,6 +41,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Out-of-scope follow-ups filed:**#50** parallel `documents_dir` detection,**#51** companion-commands(`archive-mail-view` / `archive-mail-rebuild-threads` / `archive-mail-migrate`)detection consistency,Tier C' per-contact mode(deferred until N≥3 evidence)。
 - Sister-bug observation during scout:v2.16.1 release(2026-05-09 commit `8089765`)沒寫 CHANGELOG entry — 屬 KAC sync drift,**留給 follow-up issue 補 backfill**(本 PR 不混進)。
 
+## [2.16.1] - 2026-05-09
+
+### Notes
+- **Bump-only release** to ship binary v2.7.1 + catch up tool count drift in user-facing surfaces (44 → 47)。Shell 邏輯 v2.16.0 不變,本版本只更新 wrapper 拉取的 binary tag。Backfilled per **#52** (sister concern from #49) — original v2.16.1 commit `8089765` 漏寫此 entry,KAC invariant 要求 every released version 有 entry。
+- Binary v2.7.1 ships:
+  - **#72** base64 decoding fix — attachments with unusual MIME encoding now save correctly
+  - **#69** SQLite fast-path stderr logging — silent fallback to AppleScript path now visible in logs
+  - **#66** `.partial.emlx` attachment fix — incomplete download artifacts no longer crash get_email parsing
+- Tool count drift catch-up (44 → 47): per `tool-readme-sync` audit pattern, README + plugin.json description + marketplace.json description align on the actual tool count exposed by binary v2.7.1.
+
 ## [2.16.0] - 2026-05-07
 
 ### Changed

--- a/plugins/che-apple-mail-mcp/README.md
+++ b/plugins/che-apple-mail-mcp/README.md
@@ -61,7 +61,7 @@ filters:
   - someone@example.com
 ```
 
-Detection 不會 fire,既有行為 100% backward compat。
+已 explicit-pin 的 workspace 行為不變;zero-config 且 `communications/email/` 與 `correspondence/emails/` 同時存在含 `*.md` 的 mid-migration workspace 會被 ambiguity guard flag,要求 explicit pin(避免半實作狀態的 dedup-index split-brain)。
 
 **Symlink coexistence**(transitioned-project pattern):
 

--- a/plugins/che-apple-mail-mcp/commands/archive-mail.md
+++ b/plugins/che-apple-mail-mcp/commands/archive-mail.md
@@ -379,7 +379,7 @@ fi
 
 - **Read-only**:never `mv` / `rm` / `>` against symlink target;`find` + `head` + `awk` only。
 - **Bounded**:`find -P -maxdepth 2`(symlink dir 本身 + 一層 immediate children),避免 deep archive 拖慢 startup。
-- **Resilient to schema diversity**:只 require `message_id:` field 在 YAML frontmatter 開頭~30 lines;archive-mail v2.6.0+ 全有,manual archive 若有 `message_id:` 也認得;沒有則跳過該檔(silent skip,計入 ENTRIES_THIS_DIR=0 不報)。
+- **archive-mail v2.6+ format compatibility**:設計 target 是 archive-mail 自產的 frontmatter(`message_id: "<...>"` 雙引號格式)。Manual archive 若 frontmatter 用單引號 / 內含 inline comment / CRLF / trailing whitespace,parser 會 silent skip 該檔(計入 ENTRIES_THIS_DIR=0)。Future hardening(yq parser / robust awk)deferred until N≥3 user reports of manual-archive missed dedup — see follow-up #54 / #50 for tracking。
 - **Compose with `dedup_strategy`**:僅在 `index` / `both` strategy 跑;`last_archived` strategy 完全 skip(那種 strategy 的 user 顯然不依賴 Message-ID dedup)。Compose 邏輯:`EXTENDED_DEDUP_IDS` 透過 set union 併入 existing Message-ID set,不取代 strategy-specific date predicate。
 
 **讀取附件設定**(可選):檢查 `${CONFIG_FILE}` (`.claude/.mail/config.md`) 是否有 `attachment_routing` YAML front matter 區塊。

--- a/plugins/che-apple-mail-mcp/commands/archive-mail.md
+++ b/plugins/che-apple-mail-mcp/commands/archive-mail.md
@@ -379,7 +379,7 @@ fi
 
 - **Read-only**:never `mv` / `rm` / `>` against symlink target;`find` + `head` + `awk` only。
 - **Bounded**:`find -P -maxdepth 2`(symlink dir 本身 + 一層 immediate children),避免 deep archive 拖慢 startup。
-- **archive-mail v2.6+ format compatibility**:設計 target 是 archive-mail 自產的 frontmatter(`message_id: "<...>"` 雙引號格式)。Manual archive 若 frontmatter 用單引號 / 內含 inline comment / CRLF / trailing whitespace,parser 會 silent skip 該檔(計入 ENTRIES_THIS_DIR=0)。Future hardening(yq parser / robust awk)deferred until N≥3 user reports of manual-archive missed dedup — see follow-up #54 / #50 for tracking。
+- **archive-mail v2.6+ format compatibility**:設計 target 是 archive-mail 自產的 frontmatter(`message_id: "<...>"` 雙引號格式)。Manual archive 若 frontmatter 用單引號 / 內含 inline comment / CRLF / trailing whitespace,parser 不 silent skip,而是把**malformed key**(例如 `'<abc>'` 包含單引號、含 inline comment 文字、含 `\r`)加入 in-memory dedup set;Step 4 比較 archive-mail 寫的 canonical Message-ID(`<abc>` 無外引號)時對不上,造成 **dedup miss**(historic 已 archive 的信被 re-archive)。**ENTRIES_THIS_DIR 仍會 increment**(parser 認為「成功 extract」),但 key 是 garbage,有 silent miss 風險。Future hardening(yq parser / robust awk handling 單引號 / inline comment / CRLF / trailing whitespace)deferred until N≥3 user reports of manual-archive missed dedup — see follow-up #54 / #50 for tracking。
 - **Compose with `dedup_strategy`**:僅在 `index` / `both` strategy 跑;`last_archived` strategy 完全 skip(那種 strategy 的 user 顯然不依賴 Message-ID dedup)。Compose 邏輯:`EXTENDED_DEDUP_IDS` 透過 set union 併入 existing Message-ID set,不取代 strategy-specific date predicate。
 
 **讀取附件設定**(可選):檢查 `${CONFIG_FILE}` (`.claude/.mail/config.md`) 是否有 `attachment_routing` YAML front matter 區塊。

--- a/plugins/plugin-tools/CHANGELOG.md
+++ b/plugins/plugin-tools/CHANGELOG.md
@@ -34,7 +34,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Relationship to IDD `pr_policy`**:orthogonal axes — `pr_policy` 控制 development-time PR-vs-direct-commit 決定(during `idd-implement`);Phase 0.5 控制 release-time push-or-abort 決定(during `plugin-update`)。Phase 0.5 不 consult / 不 override `pr_policy`,documented 在 phase intro。
 - Out-of-scope follow-ups already filed:**#63** (apply pattern to plugin-deploy / plugin-create — same plugin-tools family);**#65** (apply pattern to mcp-tools:mcp-deploy / cli-tools:cli-deploy — cross-marketplace);**#64** (CHANGELOG `[1.15.0]` placeholder date drift,pre-existing,unrelated);**#58** (post-marketplace-sync stale-MCP-PID warning,complementary lifecycle-end angle)。
 
-## [1.15.0] - (date unknown — please fill in)
+## [1.15.0] - 2026-04-26
 
-### Changed
-- Claude Code Plugin 完整生命週期工具：plugin-create、plugin-upgrade、plugin-deploy、plugin-update、plugin-health、plugin-debug
+### Added
+- **README Freshness Gate v2** — 從 3 信號擴展到 6,新增 3 偵測 + 2 suppressions,從跨 28 plugin 大規模 audit 萃取的盲點(commit `60f8cab`):
+  - **s4 Component inventory drift**:每個 `skills/` / `agents/` / `commands/` 下的 component 必須在 README 被 reference(backtick / slash / namespaced slash / agent at-form / bold list 任一)。Catches issue-driven-dev 5 listed vs 10 actual + mcp-tools 漏列 mcp-issue/mcp-publish/mcp-to-plugin。
+  - **s5 Tool count drift**:parse `(N tools)` / `(N MCP tools)` / `Available Tools (N)` / `N 個工具` from README header,對比 plugin.json description 的 tool count 宣稱。Catches che-ical-mcp(README 說 20、description 說 28)。
+  - **s6 Version history multi-version gap**:scan git log 找最近 90 天 same-major versions,對比 README Version History table。容忍 1 個 missing(可能 patch / internal),2+ 同 major missing 觸發 gate。Catches che-duckdb-mcp(v2.0 → v2.2.1 中 v2.1.0/v2.1.1/v2.2.0 漏列)。
+- **2 suppressions**:
+  - `no-version-section` — plugin 刻意不維護 Version History section 時 suppress version-related signals
+  - `wrapper-only commits` — commits 只動 `bin/*-wrapper.sh` 視為 binary version sync,不觸發 README staleness gate
+
+### Notes
+- Backfilled per **#64** (sister concern from #60) — original v1.15.0 release on 2026-04-26 used `changelog-tools:changelog-init` placeholder `(date unknown — please fill in)` 而沒填入。Date verified via `git show -s 60f8cab`;description detail backfilled from commit body + original `marketplace.json` description。

--- a/plugins/plugin-tools/CHANGELOG.md
+++ b/plugins/plugin-tools/CHANGELOG.md
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **s6 Version history multi-version gap**:scan git log 找最近 90 天 same-major versions,對比 README Version History table。容忍 1 個 missing(可能 patch / internal),2+ 同 major missing 觸發 gate。Catches che-duckdb-mcp(v2.0 → v2.2.1 中 v2.1.0/v2.1.1/v2.2.0 漏列)。
 - **2 suppressions**:
   - `no-version-section` — plugin 刻意不維護 Version History section 時 suppress version-related signals
-  - `wrapper-only commits` — commits 只動 `bin/*-wrapper.sh` 視為 binary version sync,不觸發 README staleness gate
+  - `wrapper-only / marketplace-sync / version-bump commits` — commits 只動 `bin/*-wrapper.sh`、`marketplace.json` sync、或 `plugin.json` version field 視為 distribution maintenance(非 substantive 改動),不觸發 README staleness gate。Filters commit message patterns 含 `(fix|chore|docs)(.*)(version-aware auto-download|sync marketplace.json|update repo URLs|wrapper)` 與 path patterns `wrapper.sh` / `marketplace.json` / `plugin.json` version。Catches `1a4c1fe` wrapper-update commit 同時 touch 9 個 plugin 但對 user 不可見的情境。
 
 ### Notes
 - Backfilled per **#64** (sister concern from #60) — original v1.15.0 release on 2026-04-26 used `changelog-tools:changelog-init` placeholder `(date unknown — please fill in)` 而沒填入。Date verified via `git show -s 60f8cab`;description detail backfilled from commit body + original `marketplace.json` description。


### PR DESCRIPTION
Refs #52 #54 #55 #64

## Summary

4-issue docs cluster from #49 + #60 IDD lifecycle follow-ups. All edits are pure documentation (no code logic change) addressing claim accuracy + CHANGELOG completeness.

## Per-issue commits

| # | Commit | Issue | Change |
|---|--------|-------|--------|
| 1 | `6602456` | #52 | che-apple-mail-mcp CHANGELOG backfill `[2.16.1] - 2026-05-09` entry (binary v2.7.1 ship + tool count drift catch-up) |
| 2 | `70e4485` | #54 | archive-mail.md Step 2.1 properties — reduce "Resilient to schema diversity" claim to v2.6+ format compatibility framing |
| 3 | `a89bca3` | #55 | che-apple-mail-mcp README — replace "100% backward compat" with explicit-pin / mid-migration distinction |
| 4 | `645d9eb` | #64 | plugin-tools CHANGELOG `[1.15.0]` — backfill date 2026-04-26 + restore feature description (s4/s5/s6 detector signals) |

## Checklist
- [x] Diagnose ✓ (issue bodies served as in-place strategy sketches; cluster Implementation Plan posted to all 4 issues before commits)
- [x] Implement (4 commits, each `Refs #N`)
- [ ] Verify (run `/idd-verify --pr <THIS_PR>`)
- [ ] **Pending: human review of this PR + per-issue `/idd-close #52 #54 #55 #64` after merge**

## Why cluster instead of 4 separate PRs

All 4 issues are pure docs, low review surface, batch-friendly. Separate PRs would create 4 review surfaces for marginal benefit. Each commit still references its source issue via `Refs #N` so audit trail per-issue is preserved.

## Out-of-scope (deferred)

- #54 parser hardening (Option B in issue body) — defer until N≥3 user reports of manual-archive missed dedup
- Other CHANGELOG drift across marketplace plugins — defer to plugin-deploy audit pass
- README Workspace Patterns broader rewrite — defer

---

🤖 Generated by /idd-implement cluster-PR mode (v2.34.0+). **Do NOT add 'Closes #N'** trailers — IDD discipline requires manual /idd-close per issue after merge to enforce checklist gate + per-issue closing summary.