### PR TITLE
fix(che-apple-mail-mcp): hook compares against binary_version not shell version

### DIFF
--- a/plugins/che-apple-mail-mcp/hooks/session-start.sh
+++ b/plugins/che-apple-mail-mcp/hooks/session-start.sh
@@ -28,9 +28,14 @@ PLUGIN_JSON="$PLUGIN_ROOT/.claude-plugin/plugin.json"
 [ -f "$RUNTIME_FILE" ] || exit 0
 [ -f "$PLUGIN_JSON" ] || exit 0
 
-# Read versions; jq returns "null" string for missing keys, so test for that too.
+# Read versions. Runtime state records BINARY tag (per #77 fix to wrapper).
+# Plugin.json has two fields since #77: .version (plugin shell) and
+# .binary_version (binary tag). Hook must compare against .binary_version
+# when present, falling back to .version for plugins not yet migrated.
+# Without this fallback chain, the hook compares runtime binary tag against
+# plugin shell version and triggers spurious kill every session (see #73).
 RUNTIME_VERSION=$(jq -r '.version_at_spawn // ""' "$RUNTIME_FILE" 2>/dev/null)
-PLUGIN_VERSION=$(jq -r '.version // ""' "$PLUGIN_JSON" 2>/dev/null)
+PLUGIN_VERSION=$(jq -r '.binary_version // .version // ""' "$PLUGIN_JSON" 2>/dev/null)
 
 [ -z "$RUNTIME_VERSION" ] && exit 0
 [ -z "$PLUGIN_VERSION" ] && exit 0

--- a/plugins/che-apple-mail-mcp/tests/test-session-start-hook.sh
+++ b/plugins/che-apple-mail-mcp/tests/test-session-start-hook.sh
@@ -87,6 +87,16 @@ EOF
     fi
 }
 
+# v2.19.5+ schema (post-#77): plugin.json has both `version` (shell) and
+# `binary_version` (binary tag). Runtime state records binary tag.
+write_plugin_json_with_binary() {
+    local shell_version="$1"
+    local binary_version="$2"
+    cat > "$FAKE_PLUGIN/.claude-plugin/plugin.json" <<EOF
+{"name":"test","version":"$shell_version","binary_version":"$binary_version"}
+EOF
+}
+
 write_runtime_file() {
     local pid="$1"
     local version="$2"
@@ -207,6 +217,46 @@ EXIT=$?
 assert "exit 0" "[ $EXIT -eq 0 ]"
 assert "no warning emitted" "[ ! -s $TEST_DIR/hook.stderr ]"
 assert "mock PID still alive" "ps -p $PID -o pid= >/dev/null 2>&1"
+kill -KILL "$PID" 2>/dev/null || true
+
+# ============================================================
+# Case 7: binary_version field present, matches runtime → no kill (#73)
+# Verifies hook prefers .binary_version over .version when comparing
+# against runtime state. Pre-#73 fix: this would FAIL because hook
+# compared runtime binary tag (2.8.5) against plugin.json shell version
+# (2.19.5), triggering unnecessary kill on every session start.
+# ============================================================
+echo "Case 7: binary_version field present, matches runtime"
+reset_state
+start_mock_pid; PID=$LAST_MOCK_PID
+# Shell v2.19.5 + binary v2.8.5 (post-#77 two-field schema)
+write_plugin_json_with_binary "2.19.5" "2.8.5"
+# Runtime state records binary tag, not shell version
+write_runtime_file "$PID" "2.8.5"
+run_hook
+EXIT=$?
+assert "exit 0" "[ $EXIT -eq 0 ]"
+assert "no warning emitted" "[ ! -s $TEST_DIR/hook.stderr ]"
+assert "mock PID still alive (binary_version matches, no kill)" "ps -p $PID -o pid= >/dev/null 2>&1"
+kill -KILL "$PID" 2>/dev/null || true
+
+# ============================================================
+# Case 8: binary_version absent (legacy schema) → fallback to .version (#73)
+# When plugin.json has no binary_version field (pre-#77 plugins), hook
+# falls back to comparing against .version. Verifies backward compat.
+# ============================================================
+echo "Case 8: binary_version absent, fallback to .version"
+reset_state
+start_mock_pid; PID=$LAST_MOCK_PID
+# Legacy single-field schema (no binary_version)
+write_plugin_json "2.17.0"
+# Runtime version_at_spawn matches plugin.json version
+write_runtime_file "$PID" "2.17.0"
+run_hook
+EXIT=$?
+assert "exit 0" "[ $EXIT -eq 0 ]"
+assert "no warning emitted" "[ ! -s $TEST_DIR/hook.stderr ]"
+assert "mock PID still alive (legacy fallback works)" "ps -p $PID -o pid= >/dev/null 2>&1"
 kill -KILL "$PID" 2>/dev/null || true
 
 # ============================================================


### PR DESCRIPTION
Refs #73

## Summary

Hook 比對 `runtime.json.version_at_spawn` (binary tag, e.g. `"2.8.5"`) against `plugin.json.version` (plugin shell version, e.g. `"2.19.5"`) — 自從 #77 引入 `binary_version` 欄位後永遠 mismatch,每次 session start spurious SIGTERM。

Fix 是 one-line jq query change:

```diff
- PLUGIN_VERSION=$(jq -r '.version // ""' "$PLUGIN_JSON" 2>/dev/null)
+ PLUGIN_VERSION=$(jq -r '.binary_version // .version // ""' "$PLUGIN_JSON" 2>/dev/null)
```

Prefer `.binary_version`,fallback `.version` for plugins not yet migrated to two-field schema(backward compat)。

## Files Changed

```
 plugins/che-apple-mail-mcp/hooks/session-start.sh  |   8 ++-
 .../tests/test-session-start-hook.sh               |  51 +++++++++++++++++-
 2 files changed, 57 insertions(+), 2 deletions(-)
```

## Tests

`bash plugins/che-apple-mail-mcp/tests/test-session-start-hook.sh` → **22/22 PASS**

- Case 7 (NEW): `binary_version` matches runtime → no kill(was FAIL in RED phase)
- Case 8 (NEW): `binary_version` absent → fallback to `.version`(backward compat)
- 6 existing cases still PASS

TDD discipline:Case 7 在 fix 前確實 FAIL(stderr shows "Killing stale" + PID died),fix 後 PASS — proves bug + fix。

## Checklist

- [x] Implement (1 commit `eee9422`)
- [ ] Verify (run `/idd-verify #73`)
- [ ] **Pending: human review of this PR + `/idd-close #73` after merge**

## Related

- **#77** — original fix(wrapper sidecar tracks binary tag);本 PR 補 fix 對應的 hook 端 incomplete migration
- **#66** — sister hardening(PID validation + started_at comparison);獨立 PR
- **PsychQuant/che-apple-mail-mcp#76** — staleness detection feature(introduced hook,本 PR 修)

---

Generated by `/idd-implement` on PR path. **Do NOT add 'Closes #73'** — IDD discipline requires manual `/idd-close` after merge to enforce checklist gate + closing summary.