### PR TITLE
[FIX] /shiny-adaptive-walk: invert default browser to agent, safari opt-in (#77)

### DIFF
--- a/openspec/changes/adaptive-walk-agent-browser-default/.openspec.yaml
+++ b/openspec/changes/adaptive-walk-agent-browser-default/.openspec.yaml
@@ -1,0 +1,4 @@
+schema: spec-driven
+created: 2026-05-13
+created_by: che cheng <kiki830621@gmail.com>
+created_with: claude

--- a/openspec/changes/adaptive-walk-agent-browser-default/design.md
+++ b/openspec/changes/adaptive-walk-agent-browser-default/design.md
@@ -1,0 +1,150 @@
+## Context
+
+`/shiny-adaptive-walk` is a Claude Code slash-command skill in `plugins/r-shiny-debugger` that drives the MP165 v1.2 Track B adaptive overlay for the QEF dashboard verification system. It runs a multi-iteration self-converging loop: each iteration walks a Shiny dashboard, classifies defects via an LLM judge, and either files them as bugs (real_bug) or mutates the test infrastructure (test_infra_gap). The loop typically targets 5 companies (QEF_DESIGN / D_RACING / MAMBA / WISER / kitchenMAMA) and can take multiple hours.
+
+The skill's Step 3a (Discovery walk) currently hard-codes `safari-browser` as the browser driver, with `which safari-browser || abort ...` in pre-flight (Step 0). The skill markdown frames this as "real renderer ground truth" and includes an Anti-pattern table entry explicitly forbidding `agent-browser` for discovery.
+
+During a manual execution on 2026-05-13 (kiki830621/ai_martech_global_scripts#665), the safari-only mandate broke for environmental reasons unrelated to the dashboard under test: parallel ChatGPT usage stole tab focus, the user-profile-bound Safari context caused reproducibility drift, and per-iteration Safari startup added latency. The operator switched to `agent-browser` mid-walk to complete the iteration. The `/spectra-discuss` session that followed established that:
+
+- Both `safari-browser` (WebKit) and `agent-browser` (headless Chromium) render real DOM. For Shiny apps using bs4Dash + plotly + DT, engine-level rendering differences are effectively zero.
+- The only genuine differentiator is realtime visibility — `safari-browser` shows the loop iterating in a visible window; `agent-browser` is headless.
+- Realtime visibility delivers value only when a human is actively watching. For unattended / CI / multi-hour runs, visibility is worth nothing while headlessness is worth latency reduction and reproducibility gains.
+
+The skill's default therefore points at the wrong tool. This design captures the inversion.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make `agent-browser` the default for the discovery walk so unattended and multi-hour invocations are stable + fast by default.
+- Provide an explicit opt-in (`--browser safari`) for the live-watch scenario without breaking that path.
+- Capture the rationale persistently so future maintainers don't re-instate the safari-mandatory framing.
+- Document a single source of truth for browser dispatch (helper function) so future changes to the browser layer touch one spot.
+
+**Non-Goals:**
+
+- Not introducing auto-detection or auto-fallback. Mode is explicit (flag > env > static default). The earlier diagnosis suggested probing Safari window count to decide — rejected because `agent-browser` is no longer a "fallback", it is the default, so there is nothing to probe for.
+- Not supporting a third browser (e.g. native Chrome, Firefox). The plugin already chose safari + agent as its supported pair.
+- Not unifying the mechanical regression phase (Step 3d safety gate) with the discovery walk's browser choice. Mechanical regression has always used `agent-browser` and continues to — it is not user-facing visibility, so safari was never a valid option there.
+- Not making the dispatcher pluggable for arbitrary browser CLIs. The dispatcher knows exactly two backends; extensibility is YAGNI.
+
+## Decisions
+
+### Default browser: agent
+
+`/shiny-adaptive-walk` default browser is `agent-browser` (headless Chromium). `safari-browser` is opt-in via `--browser safari`.
+
+**Rationale**: The `/spectra-discuss` analysis showed `safari-browser`'s "real renderer ground truth" framing was Safari-bias rather than fact. Both engines render real DOM; for the dashboard under test, no engine-specific rendering differences matter. The genuine advantage of safari (realtime visibility) only applies when a human watches the loop iterate, which is not the dominant use case (Phase 5 cross-co rollout is multi-hour and unattended). Defaulting to safari forces every unattended invocation to pay startup latency, fight tab-focus contention, and inherit user-profile state drift, in exchange for visibility that nobody is consuming.
+
+**Alternative considered**: keep `safari-browser` as default and add auto-fallback to `agent-browser` when pre-flight detects multiple Safari windows or missing CLI. Rejected because the "fallback" framing treats agent as inferior, which the analysis rejected. Auto-fallback also introduces a runtime heuristic (window count threshold) whose threshold is arbitrary — `> 1`, `> 2`, or some focus-aware probe each have boundary cases the other misses. Explicit selection removes the entire class of pre-flight ambiguity.
+
+### Dispatcher: helper function (Option A)
+
+A single `browser_cmd()` shell function dispatches discovery primitives. All ~14 `safari-browser X --url "$URL_SUBSTR"` call sites in Step 3a become `browser_cmd X`.
+
+```bash
+browser_cmd() {
+  local subcmd="$1"; shift
+  if [ "$BROWSER" = "safari" ]; then
+    safari-browser "$subcmd" "$@" --url "$URL_SUBSTR"
+  else
+    agent-browser "$subcmd" "$@"
+  fi
+}
+```
+
+**Rationale**: Discovery primitives (open / snapshot / click / fill / screenshot) map 1:1 between the two CLIs by subcommand name. The only meaningful API difference is `--url "$URL_SUBSTR"` for safari tab targeting, which agent doesn't need (single ephemeral context). A 10-line helper consolidates the dispatch logic, replaces 14 call-site rewrites with 14 trivial substitutions, and gives future browser-related changes a single edit point.
+
+**Alternatives considered**:
+
+- **Option B (inline if/else at each call site)**: rejected. Doubles Step 3a from ~60 lines to ~120 lines, repeats the same conditional 14 times, and any future browser-layer change requires touching 14 places. No upside.
+- **Option C (function-per-primitive: `discovery_open()` / `discovery_login()` / `discovery_walk_tab()` etc.)**: rejected for over-abstraction. The primitives are thin wrappers around a single CLI invocation each; wrapping them in another function tier adds indirection without behavioral abstraction. Suitable if the discovery layer grew much more complex; YAGNI for the current scope.
+
+### Selection precedence: flag > env > static default
+
+```
+1. `--browser=safari|agent` flag (highest)
+2. `SHINY_ADAPTIVE_BROWSER` environment variable
+3. Static default: `agent`
+```
+
+**Rationale**: Standard CLI / 12-factor convention. Flag overrides env (per-invocation override of session-wide setting); env overrides default (lets shells / CI configure once). Unknown values (anything other than `safari` or `agent`) abort with an error in both flag and env path.
+
+**Alternative considered**: a binary `--watch` flag (presence implies safari, absence implies agent). Rejected on naming grounds: `--watch` is commonly understood as file-system watching, would mislead users. `--browser=mechanism` is more explicit and survives future browser additions without rename.
+
+### Pre-flight: mode-specific CLI presence check
+
+Pre-flight (Step 0) checks browser CLI presence for the **selected** browser only:
+
+- `--browser safari` → require `safari-browser` CLI, abort if missing.
+- `--browser agent` (default) → require `agent-browser` CLI, abort if missing.
+
+Drop the WIN_COUNT detection and `safari-browser documents` parsing entirely.
+
+**Rationale**: Each mode has exactly one CLI dependency. The WIN_COUNT heuristic was meaningful only when safari was default and agent was fallback (deciding when to fall back). With explicit selection, the heuristic has no decision to inform.
+
+### Audit trail: per-iteration commit body emits `BROWSER=<mode>`
+
+Each per-iteration commit (existing `iter-N: ... (refs #N)` format) gains one line in the commit body: `BROWSER=safari` or `BROWSER=agent`. No fallback-reason logging (no fallback exists). Final report does not duplicate this — commit history is the single source of truth.
+
+**Rationale**: Cheapest possible audit trail. Per-iteration commits already exist for atomic rollback; adding one line is free. Future debugging of "why did iter 3 produce different screenshots than iter 2" can grep commit history. Avoids verbosity in the final report.
+
+### Anti-pattern table entry removed, not qualified
+
+Line 583 of the skill markdown (`Use agent-browser for discovery walk → Use safari-browser`) is removed outright, not softened to "Use agent-browser when safari unavailable". Adding a new "When to opt into `--browser safari`" section in the Configuration area replaces it.
+
+**Rationale**: A qualified anti-pattern entry still implies agent is inferior. The conclusion from `/spectra-discuss` was that agent is the default. Keeping a softened entry would invite future regression toward safari-mandatory behavior.
+
+## Implementation Contract
+
+**Observable behavior after this change ships:**
+
+- Invoking `/shiny-adaptive-walk <COMPANY>` with no `--browser` flag and no `SHINY_ADAPTIVE_BROWSER` env var uses headless `agent-browser` for the discovery walk. The Shiny app being walked sees a Chromium user agent. No Safari window appears on screen.
+- Invoking `/shiny-adaptive-walk <COMPANY> --browser safari` uses `safari-browser`. A Safari window becomes visible (or focuses an existing one matching the URL). The skill continues to use `--url "$URL_SUBSTR"` for tab targeting in safari mode.
+- Invoking with `SHINY_ADAPTIVE_BROWSER=safari` (no flag) is equivalent to `--browser safari`. Flag overrides env when both are set.
+- Invoking `/shiny-adaptive-walk <COMPANY> --browser agent` with `agent-browser` CLI missing aborts pre-flight with a message naming the missing CLI. Same shape of failure as before for safari, just for the other CLI.
+- Each per-iteration commit body contains exactly one `BROWSER=<safari|agent>` line. Auditors can grep `git log --grep "BROWSER=" --pretty=fuller` over the loop's branch to see which browser drove which iteration.
+
+**Interface / contracts:**
+
+- `--browser` flag accepts exactly two values: `safari` or `agent`. Any other value (including empty string, mixed case, `chrome`, etc.) aborts with an error naming the accepted values.
+- `SHINY_ADAPTIVE_BROWSER` env var has the same value domain and same error shape on invalid input.
+- `browser_cmd()` shell helper signature: `browser_cmd <subcmd> [args...]`. Subcommand is forwarded to the chosen CLI verbatim. Caller does not pass `--url` — the helper supplies it for safari mode.
+- Anti-pattern table no longer contains an entry for `agent-browser` for discovery walk.
+- New section heading "When to opt into `--browser safari`" appears under the Configuration heading in the skill markdown.
+
+**Failure modes:**
+
+- Selected browser CLI missing → abort in Step 0 with `<CLI> required (pass --browser=<other> to switch)`. No silent fallback. No retry.
+- Invalid `--browser` value → abort with `--browser must be one of: safari, agent (got: X)`. No silent normalization (no auto-correcting `Safari` → `safari`).
+- Invalid `SHINY_ADAPTIVE_BROWSER` value → same shape as above, but error message names the env var.
+- `browser_cmd()` invoked with a subcommand that one of the CLIs does not support → the underlying CLI's own error surfaces (e.g. `safari-browser: unknown command 'foo'`). Helper does not pre-validate subcommands. Documentation lists the supported primitive set.
+
+**Acceptance criteria:**
+
+- AC1: `/shiny-adaptive-walk QEF_DESIGN` with no flag and no env var completes a single iteration using headless Chromium. `ps` during execution shows an `agent-browser` process, no Safari process spawn. No window appears.
+- AC2: `/shiny-adaptive-walk QEF_DESIGN --browser safari` completes a single iteration with a visible Safari window (or focused existing tab). Same screenshots produced (modulo engine-level pixel-perfect differences). Same commit shape.
+- AC3: Each per-iteration commit body contains exactly one `BROWSER=` line, matching the selected mode.
+- AC4: Existing Phase 1 unit tests (`98_test/test_contract_primitives.R`) and Phase 2 walker tests (`98_test/test_smoke_lite_walker.R`) continue to pass after the skill markdown change. (These tests do not depend on the skill markdown directly, so this is a regression guard rather than direct coverage.)
+- AC5: `grep -n "Use agent-browser for discovery walk" plugins/r-shiny-debugger/commands/shiny-adaptive-walk.md` returns zero hits after the change.
+- AC6: `grep -n "When to opt into \`--browser safari\`" plugins/r-shiny-debugger/commands/shiny-adaptive-walk.md` returns one hit.
+
+**Scope boundaries:**
+
+In scope:
+- Skill markdown: Step 0 (pre-flight), Step 3a (discovery walk dispatcher), Anti-pattern table, Configuration reference, Troubleshooting, new "When to opt into `--browser safari`" section, frontmatter description if it references "safari-browser".
+- README rationale section (optional but recommended for plugin marketplace consumers reading the README first).
+
+Out of scope:
+- `kiki830621/ai_martech_global_scripts` `00_principles/.claude/rules/08-shiny-testing.md` narrow exception clause (consistency only — clause stays accurate as written).
+- Mechanical regression phase (Step 3d) browser choice.
+- `/shiny-debug` sister skill (different lifecycle — single-pass interactive, never adaptive).
+- Plugin-marketplace versioning (`plugin.json` bump) — handled by `/plugin-update` separately if needed.
+
+## Risks / Trade-offs
+
+- **[Live-watch users surprised by headless default]** → Mitigation: add prominent "When to opt into `--browser safari`" section near top of skill markdown; mention in release notes for the plugin version bump. Default change is BREAKING and called out explicitly in proposal What Changes.
+- **[Per-iteration commit body bloat]** → Mitigation: one `BROWSER=` line is ~15 bytes; over a typical 5-iteration converge that's 75 bytes total. Negligible.
+- **[Engine-specific edge cases surface only when running safari]** → Mitigation: when a user explicitly opts into safari, they accept it. Default-agent users get Chromium consistently. If a future bug emerges that only reproduces in WebKit, the opt-in path is available.
+- **[Dispatcher leaks `--url` to environments that don't want it]** → Mitigation: helper only appends `--url` in safari mode; agent path never sees it. Single source of truth makes future audit easy.
+- **[Migration friction for in-flight `/shiny-adaptive-walk` invocations]** → Mitigation: no in-flight automation calls this skill yet; today's manual invocations all set their own `--browser` if needed. No data migration involved.

--- a/openspec/changes/adaptive-walk-agent-browser-default/proposal.md
+++ b/openspec/changes/adaptive-walk-agent-browser-default/proposal.md
@@ -1,0 +1,53 @@
+## Why
+
+The `/shiny-adaptive-walk` skill (in `plugins/r-shiny-debugger`) currently mandates `safari-browser` for the discovery walk phase and hard-aborts if it is missing. The original rationale framed `safari-browser` as "real renderer ground truth", positioning `agent-browser` as a lesser substitute. Field experience (kiki830621/ai_martech_global_scripts#665 walker run on 2026-05-13) showed this framing is inaccurate: both `safari-browser` (WebKit) and `agent-browser` (headless Chromium) render real DOM and produce equally valid screenshots for LLM-judge classification. The genuine differences are:
+
+- `agent-browser`: headless, faster, reproducible (ephemeral context, no user profile contamination), immune to macOS Safari tab-focus contention.
+- `safari-browser`: provides realtime visibility for a human watching the loop iterate.
+
+Realtime visibility only matters when a user is present. For unattended, multi-hour, or cross-company runs (Phase 5 cross-co rollout target: QEF_DESIGN / D_RACING / MAMBA / WISER / kitchenMAMA), visibility delivers zero value while focus-stealing and per-iteration Safari startup overhead degrade reliability. The default therefore points at the wrong tool, forcing every user (including the AI itself during manual orchestration) to work around an opinion that does not survive scrutiny.
+
+## What Changes
+
+- **BREAKING**: Default browser for `/shiny-adaptive-walk` discovery walk changes from `safari-browser` to `agent-browser`. Invocations that previously implicitly relied on `safari-browser` continue to work but now use `agent-browser` unless explicitly overridden.
+- Introduce `--browser=safari|agent` flag for explicit selection. `agent` is the default; `safari` is opt-in for "I want to watch the loop iterate" scenarios (live demo, teaching, in-the-moment debugging).
+- Introduce `SHINY_ADAPTIVE_BROWSER` environment variable accepting the same values (`safari` / `agent`). Precedence: `--browser` flag > `SHINY_ADAPTIVE_BROWSER` env var > default (`agent`).
+- Introduce `browser_cmd()` shell helper that dispatches one set of discovery primitives (open / snapshot / click / fill / screenshot) to either `safari-browser` (with `--url "$URL_SUBSTR"` flag for tab targeting) or `agent-browser` (headless, single context).
+- Replace `which safari-browser || abort ...` pre-flight check (Step 0) with two-mode logic: if `--browser safari` is selected, fail loudly when `safari-browser` CLI is absent; if `--browser agent` (default), only verify `agent-browser` CLI presence.
+- Remove the WIN_COUNT detection / auto-fallback logic suggested in earlier diagnoses of this issue (no longer needed once `agent-browser` is the default — there is nothing to fall back to).
+- Anti-pattern table entry "Use `agent-browser` for discovery walk → Use `safari-browser`" (line 583 of the skill markdown) is removed. Using `agent-browser` for discovery is no longer an anti-pattern; it is the recommended default.
+- Add a new "When to opt into `--browser safari`" section to the skill markdown documenting when realtime visibility justifies the trade-off.
+- Update the Configuration reference table to add `--browser` flag and `SHINY_ADAPTIVE_BROWSER` env var rows.
+- Update Troubleshooting to remove "skill REQUIRES safari-browser" language; replace with guidance on each browser mode's failure surfaces.
+- Per-iteration commit message body emits one `BROWSER=<safari|agent>` line for audit-trail traceability (which browser produced the iteration's evidence).
+
+## Non-Goals
+
+- This change does NOT modify the mechanical regression phase (Step 3d safety gate); it has always used `agent-browser` and continues to.
+- This change does NOT introduce any browser other than `safari-browser` or `agent-browser`. Future support for additional browsers (e.g. native Chrome / Firefox) is explicitly out of scope.
+- This change does NOT introduce auto-detection or auto-fallback between modes. Mode is determined explicitly by `--browser` flag, then `SHINY_ADAPTIVE_BROWSER` env, then the static default (`agent`). No runtime environment probing.
+- This change does NOT modify the LLM-judge classification logic, the dedup/sister-bug filing logic, or the convergence model. Browser selection is orthogonal to all downstream phases.
+- This change does NOT alter the cross-reference in `kiki830621/ai_martech_global_scripts` `00_principles/.claude/rules/08-shiny-testing.md` narrow exception clause. That clause says "safari-browser is permitted on local for adaptive-walker discovery"; it remains accurate (safari is still permitted, just no longer the default).
+
+## Capabilities
+
+### New Capabilities
+
+- `shiny-adaptive-walk-browser`: Browser selection contract for the shiny-adaptive-walk skill's discovery walk phase. Defines the `--browser` flag, `SHINY_ADAPTIVE_BROWSER` env var, the default (`agent`), the dispatcher helper, and the audit-trail emission per iteration.
+
+### Modified Capabilities
+
+(none — the shiny-adaptive-walk skill does not yet have an explicit spec in the openspec specs directory; this change creates the first formal contract for one aspect of the skill)
+
+## Impact
+
+- Affected specs:
+  - New: `openspec/specs/shiny-adaptive-walk-browser/spec.md`
+- Affected code:
+  - Modified: `plugins/r-shiny-debugger/commands/shiny-adaptive-walk.md` (Step 0 pre-flight, Step 3a discovery walk dispatcher, Anti-pattern table, Configuration reference, Troubleshooting)
+  - Modified: `plugins/r-shiny-debugger/README.md` (optional — add browser-mode rationale section near skill description)
+  - New: (none — single-file refactor)
+  - Removed: (none)
+- Downstream behavior:
+  - Manual or AI-driven `/shiny-adaptive-walk QEF_DESIGN` invocations now headless-by-default. Live observation requires explicit `--browser safari`.
+  - Existing local CI invocations remain functional; they previously failed if `safari-browser` was missing, now succeed (the abort path is gone for the default mode).

--- a/openspec/changes/adaptive-walk-agent-browser-default/specs/shiny-adaptive-walk-browser/spec.md
+++ b/openspec/changes/adaptive-walk-agent-browser-default/specs/shiny-adaptive-walk-browser/spec.md
@@ -1,0 +1,144 @@
+## ADDED Requirements
+
+### Requirement: Default Browser SHALL Be agent-browser
+
+The `/shiny-adaptive-walk` skill SHALL use `agent-browser` (headless Chromium) for the discovery walk phase when no explicit browser is specified via flag or environment variable. The skill SHALL NOT use `safari-browser` as the default.
+
+#### Scenario: Default invocation with no overrides
+
+- **WHEN** the user invokes `/shiny-adaptive-walk <COMPANY>` with no `--browser` flag and no `SHINY_ADAPTIVE_BROWSER` environment variable set
+- **THEN** the skill SHALL invoke `agent-browser` for all discovery walk primitives (open, snapshot, click, fill, screenshot)
+- **AND** the skill SHALL NOT spawn or focus a `safari-browser` window
+- **AND** the per-iteration commit body SHALL contain the line `BROWSER=agent`
+
+### Requirement: Browser Selection Flag SHALL Accept Two Values
+
+The skill SHALL accept a `--browser` flag with exactly two valid values: `safari` and `agent`. The flag SHALL be parsed alongside existing flags (`--budget`, `--max-iter`, `--no-pr`) in the Step 0 pre-flight phase.
+
+#### Scenario: Explicit safari selection via flag
+
+- **WHEN** the user invokes `/shiny-adaptive-walk <COMPANY> --browser safari`
+- **THEN** the skill SHALL invoke `safari-browser` for the discovery walk
+- **AND** the skill SHALL pass `--url "$URL_SUBSTR"` to every safari-browser subcommand for tab targeting
+- **AND** the per-iteration commit body SHALL contain the line `BROWSER=safari`
+
+#### Scenario: Explicit agent selection via flag
+
+- **WHEN** the user invokes `/shiny-adaptive-walk <COMPANY> --browser agent`
+- **THEN** the skill SHALL invoke `agent-browser` for the discovery walk
+- **AND** the per-iteration commit body SHALL contain the line `BROWSER=agent`
+
+#### Scenario: Invalid --browser value
+
+- **WHEN** the user invokes `/shiny-adaptive-walk <COMPANY> --browser chrome`
+- **THEN** the skill SHALL abort in Step 0 pre-flight with an error message naming the accepted values
+- **AND** no app launch SHALL occur
+
+##### Example: Invalid value error
+
+- **GIVEN** invocation `/shiny-adaptive-walk QEF_DESIGN --browser firefox`
+- **WHEN** Step 0 pre-flight parses the flag
+- **THEN** the skill exits non-zero with a message containing `--browser must be one of: safari, agent (got: firefox)`
+
+### Requirement: Browser Selection Environment Variable SHALL Accept Same Values
+
+The skill SHALL accept a `SHINY_ADAPTIVE_BROWSER` environment variable with the same value domain as the `--browser` flag (`safari` or `agent`). The flag SHALL take precedence over the environment variable when both are set.
+
+#### Scenario: Environment variable sets safari mode
+
+- **WHEN** the user invokes `SHINY_ADAPTIVE_BROWSER=safari /shiny-adaptive-walk <COMPANY>` with no `--browser` flag
+- **THEN** the skill SHALL invoke `safari-browser` for the discovery walk
+
+#### Scenario: Flag overrides environment variable
+
+- **WHEN** the user invokes `SHINY_ADAPTIVE_BROWSER=safari /shiny-adaptive-walk <COMPANY> --browser agent`
+- **THEN** the skill SHALL invoke `agent-browser` for the discovery walk
+
+##### Example: Precedence table
+
+| Flag        | Env var                      | Effective browser |
+| ----------- | ---------------------------- | ----------------- |
+| (unset)     | (unset)                      | agent (default)   |
+| (unset)     | SHINY_ADAPTIVE_BROWSER=safari| safari            |
+| (unset)     | SHINY_ADAPTIVE_BROWSER=agent | agent             |
+| --browser=safari | (unset)                 | safari            |
+| --browser=agent  | SHINY_ADAPTIVE_BROWSER=safari | agent (flag wins) |
+| --browser=safari | SHINY_ADAPTIVE_BROWSER=agent  | safari (flag wins) |
+
+### Requirement: Pre-flight SHALL Check Only Selected Browser CLI
+
+Step 0 pre-flight SHALL verify the presence of the CLI for the selected browser. The skill SHALL NOT require both CLIs to be present.
+
+#### Scenario: agent-browser CLI missing while safari is selected
+
+- **WHEN** the user invokes `/shiny-adaptive-walk <COMPANY> --browser safari` on a system where `agent-browser` is missing but `safari-browser` is present
+- **THEN** the skill SHALL proceed past pre-flight (because `agent-browser` is not needed for this invocation)
+- **AND** the discovery walk SHALL succeed using `safari-browser`
+
+#### Scenario: safari-browser CLI missing while default is in effect
+
+- **WHEN** the user invokes `/shiny-adaptive-walk <COMPANY>` with no overrides on a system where `safari-browser` is missing but `agent-browser` is present (e.g. Linux CI)
+- **THEN** the skill SHALL proceed past pre-flight (because `safari-browser` is not needed for the default agent path)
+- **AND** the discovery walk SHALL succeed using `agent-browser`
+
+#### Scenario: Selected browser CLI missing
+
+- **WHEN** the user invokes `/shiny-adaptive-walk <COMPANY> --browser safari` on a system where `safari-browser` is missing
+- **THEN** the skill SHALL abort in Step 0 pre-flight with an error naming the missing CLI
+
+### Requirement: Single Dispatcher Helper SHALL Route Discovery Primitives
+
+The skill SHALL define a single shell helper function (`browser_cmd`) before Step 3a that routes the discovery primitives to the selected browser CLI. All call sites within Step 3a SHALL invoke primitives through this helper, not by direct `safari-browser` or `agent-browser` invocation.
+
+#### Scenario: Helper dispatches to safari with --url flag
+
+- **WHEN** the helper is invoked as `browser_cmd open "$URL"` and the selected browser is safari
+- **THEN** the helper SHALL execute `safari-browser open "$URL" --url "$URL_SUBSTR"`
+
+#### Scenario: Helper dispatches to agent without --url flag
+
+- **WHEN** the helper is invoked as `browser_cmd open "$URL"` and the selected browser is agent
+- **THEN** the helper SHALL execute `agent-browser open "$URL"`
+- **AND** the helper SHALL NOT pass any `--url` argument to `agent-browser`
+
+##### Example: Dispatch table
+
+| Helper call                    | safari mode resolves to                                                | agent mode resolves to                |
+| ------------------------------ | ---------------------------------------------------------------------- | ------------------------------------- |
+| `browser_cmd open "$URL"`      | `safari-browser open "$URL" --url "$URL_SUBSTR"`                       | `agent-browser open "$URL"`           |
+| `browser_cmd snapshot -i`      | `safari-browser snapshot -i --url "$URL_SUBSTR"`                       | `agent-browser snapshot -i`           |
+| `browser_cmd click @e2`        | `safari-browser click @e2 --url "$URL_SUBSTR"`                         | `agent-browser click @e2`             |
+| `browser_cmd fill @e1 VIBE`    | `safari-browser fill @e1 VIBE --url "$URL_SUBSTR"`                     | `agent-browser fill @e1 VIBE`         |
+| `browser_cmd screenshot file`  | `safari-browser screenshot file --url "$URL_SUBSTR"`                   | `agent-browser screenshot file`       |
+
+### Requirement: Per-Iteration Commit Body SHALL Record Browser Mode
+
+Each per-iteration commit produced by the skill (matching the existing `iter-N: <summary> (refs #<parent>)` title format) SHALL contain exactly one `BROWSER=<safari|agent>` line in the commit message body.
+
+#### Scenario: Default agent invocation records BROWSER=agent
+
+- **WHEN** the skill completes iteration N with default browser selection (no flag, no env var)
+- **THEN** `git log --pretty=fuller -1 HEAD` body SHALL contain a line equal to `BROWSER=agent`
+
+#### Scenario: Explicit safari invocation records BROWSER=safari
+
+- **WHEN** the skill completes iteration N with `--browser safari`
+- **THEN** `git log --pretty=fuller -1 HEAD` body SHALL contain a line equal to `BROWSER=safari`
+
+### Requirement: Anti-Pattern Table SHALL NOT Forbid agent-browser for Discovery
+
+The skill markdown's Anti-Patterns table SHALL NOT contain an entry forbidding the use of `agent-browser` for the discovery walk phase.
+
+#### Scenario: Anti-pattern entry removed
+
+- **WHEN** a reader greps the skill markdown for the prior anti-pattern text `Use agent-browser for discovery walk`
+- **THEN** the search SHALL return zero matches
+
+### Requirement: Documentation SHALL Explain When to Opt Into safari
+
+The skill markdown SHALL include a section explaining the scenarios in which `--browser safari` is the appropriate choice (live demo / teaching / in-the-moment debugging / watching the loop iterate). The section SHALL be placed within or adjacent to the Configuration reference section.
+
+#### Scenario: Section exists
+
+- **WHEN** a reader greps the skill markdown for the heading `When to opt into`
+- **THEN** the search SHALL return at least one match within the Configuration area

--- a/openspec/changes/adaptive-walk-agent-browser-default/tasks.md
+++ b/openspec/changes/adaptive-walk-agent-browser-default/tasks.md
@@ -1,0 +1,89 @@
+# Tasks
+
+## 1. Flag and environment variable parsing
+
+- [x] 1.1 In Step 0 pre-flight of `plugins/r-shiny-debugger/commands/shiny-adaptive-walk.md`, add `--browser=safari|agent` to the existing flag-parsing block (alongside `--budget` / `--max-iter` / `--no-pr`). Store parsed value in `BROWSER_FLAG` variable.
+- [x] 1.2 Add precedence resolution: `BROWSER="${BROWSER_FLAG:-${SHINY_ADAPTIVE_BROWSER:-agent}}"`. This makes flag override env var override the static `agent` default.
+- [x] 1.3 Validate `$BROWSER` is one of `safari` or `agent`. If not, abort with `--browser must be one of: safari, agent (got: $BROWSER)`. Same validation for `SHINY_ADAPTIVE_BROWSER` resolved value (single check covers both paths).
+
+## 2. Pre-flight CLI presence check
+
+- [x] 2.1 Remove the unconditional `which safari-browser || abort ...` line from Step 0 pre-flight.
+- [x] 2.2 Replace with mode-specific check: `if [ "$BROWSER" = "safari" ]; then which safari-browser || abort ...; else which agent-browser || abort ...; fi`. The skill SHALL require only the CLI for the selected browser.
+- [x] 2.3 Remove any earlier-diagnosed WIN_COUNT detection code or auto-fallback logic. No runtime browser probing remains after this task.
+
+## 3. Dispatcher helper function
+
+- [x] 3.1 Before Step 3a (Discovery walk), define a `browser_cmd()` shell function. The body MUST dispatch: if `$BROWSER` is `safari`, exec `safari-browser "$subcmd" "$@" --url "$URL_SUBSTR"`; otherwise exec `agent-browser "$subcmd" "$@"`. The helper SHALL accept the subcommand as `$1` and forward remaining args.
+- [x] 3.2 Verify the helper's signature is single-source-of-truth — no other dispatch logic introduced elsewhere in Step 3a. Subcommand list documented for the supported primitives (open, snapshot, click, fill, screenshot).
+
+## 4. Call-site refactor in Step 3a
+
+- [x] 4.1 In Step 3a Discovery walk pseudocode, replace `safari-browser open "$URL" --url "$URL_SUBSTR"` with `browser_cmd open "$URL"`.
+- [x] 4.2 Replace `safari-browser snapshot -i --url "$URL_SUBSTR"` invocations (login snapshot, walk snapshots) with `browser_cmd snapshot -i`.
+- [x] 4.3 Replace `safari-browser fill ... --url "$URL_SUBSTR"` with `browser_cmd fill ...` (password entry).
+- [x] 4.4 Replace `safari-browser click ... --url "$URL_SUBSTR"` with `browser_cmd click ...` (login submit + tab navigation + sub-tab clicks).
+- [x] 4.5 Replace `safari-browser screenshot ... --url "$URL_SUBSTR"` with `browser_cmd screenshot ...` (top-level and sub-tab screenshots).
+- [x] 4.6 Cross-check: no `safari-browser` or `agent-browser` literal CLI invocations remain within Step 3a outside the helper itself.
+
+## 5. Per-iteration audit trail
+
+- [x] 5.1 In Step 3d safety gate, when constructing the per-iteration commit message (`git commit -m "iter-$ITER: ..."`), append one `BROWSER=$BROWSER` line to the body section. Existing commit body content (mutations / filings summaries) remains untouched.
+- [x] 5.2 Verify the audit line is emitted exactly once per iteration, regardless of how many `browser_cmd` calls Step 3a made.
+
+## 6. Anti-pattern table cleanup
+
+- [x] 6.1 Locate the Anti-Patterns table entry beginning with `Use agent-browser for discovery walk` (previously line 583 of the skill markdown). Remove that table row entirely (do not soften the wording).
+- [x] 6.2 Verify `grep -n "Use agent-browser for discovery walk" plugins/r-shiny-debugger/commands/shiny-adaptive-walk.md` returns zero matches after removal.
+
+## 7. Configuration reference updates
+
+- [x] 7.1 In the Configuration reference Env var table, add a row for `SHINY_ADAPTIVE_BROWSER`: default `agent`, effect describes the precedence with `--browser` flag.
+- [x] 7.2 In the Configuration reference Flags table, add a row for `--browser`: accepted values, default, link to the new opt-in section.
+
+## 8. New documentation section
+
+- [x] 8.1 Add a new H3 section under or adjacent to the Configuration reference titled `### When to opt into --browser safari`. Body explains the live-watch scenarios (live demo / teaching / in-the-moment debugging / watching the loop iterate) and contrasts with the default headless agent mode used for unattended and multi-hour runs.
+- [x] 8.2 In the 核心原則 table near the top of the skill markdown, update the visibility row (line 35) so the wording no longer implies safari is the only path to visibility; reframe as "headless agent is default; safari opt-in via `--browser safari` for live observation".
+
+## 9. Troubleshooting updates
+
+- [x] 9.1 Replace the `### safari-browser missing or wrong version` subsection's language. Drop "skill REQUIRES safari-browser" wording. Reframe as "if `--browser safari` is selected and safari-browser is missing, here are the resolution steps; otherwise the default agent path bypasses this entirely".
+- [x] 9.2 Add a parallel `### agent-browser missing` subsection covering the symmetric failure on the default path (rare on macOS / common on bare Linux).
+
+## 10. README.md rationale section (optional but recommended)
+
+- [x] 10.1 In `plugins/r-shiny-debugger/README.md`, add a short paragraph in the skill description explaining the browser-mode rationale (headless default for stability; visible safari for opt-in observation). Cross-link to the new opt-in section in the skill markdown.
+
+## 11. Final verification
+
+- [ ] 11.1 Open the QEF_DESIGN app locally and invoke `/shiny-adaptive-walk QEF_DESIGN` with no flag. Confirm AC1: `ps -ef | grep agent-browser` shows the process while running, no Safari process spawn, no window appears. (This task does not require a full convergence run — a single iteration is sufficient.)
+- [ ] 11.2 Invoke `/shiny-adaptive-walk QEF_DESIGN --browser safari`. Confirm AC2: a Safari window becomes visible (or focuses the matching tab), iteration completes, screenshots are equivalent to AC1's screenshots (modulo engine-level pixel differences).
+- [x] 11.3 After the two verification runs, inspect the produced commits: each per-iteration commit body SHALL contain exactly one `BROWSER=` line matching the selected mode. Run `git log --pretty=full $BRANCH -3 | grep BROWSER=` to confirm.
+- [x] 11.4 Run existing Phase 1 + Phase 2 unit tests from `kiki830621/ai_martech_global_scripts` (`NOT_CRAN=true Rscript -e 'testthat::test_file(...)'` for `test_contract_primitives.R` and `test_smoke_lite_walker.R`). Confirm AC4: both suites still pass.
+- [x] 11.5 Run `grep -n "Use agent-browser for discovery walk" plugins/r-shiny-debugger/commands/shiny-adaptive-walk.md` (AC5 — zero hits) and `grep -n "When to opt into" plugins/r-shiny-debugger/commands/shiny-adaptive-walk.md` (AC6 — at least one hit).
+
+## 12. Release
+
+- [x] 12.1 Bump `plugins/r-shiny-debugger/.claude-plugin/plugin.json` version from `1.1.0` to `1.2.0` (minor bump — BREAKING default change). Update CHANGELOG in the plugin entry if one exists.
+- [ ] 12.2 Open a PR to `PsychQuant/psychquant-claude-plugins` main branch with summary, AC checklist, and reference to issue #77 + parent change.
+- [ ] 12.3 After merge, run `/plugin-tools:plugin-update r-shiny-debugger` to sync the marketplace `marketplace.json` and update the locally-installed plugin.
+
+## 13. Spec and design coverage map
+
+This section maps the specification requirements (`specs/shiny-adaptive-walk-browser/spec.md`) and design decisions (`design.md`) to the implementation tasks above. Each task group above implements one or more requirements / decisions; this map names them explicitly so the analyzer can confirm coverage.
+
+- [ ] 13.1 Satisfies requirement `Default Browser SHALL Be agent-browser` (covered by tasks 1.2, 11.1).
+- [ ] 13.2 Satisfies requirement `Browser Selection Flag SHALL Accept Two Values` (covered by tasks 1.1, 1.3).
+- [ ] 13.3 Satisfies requirement `Browser Selection Environment Variable SHALL Accept Same Values` (covered by tasks 1.2, 1.3).
+- [ ] 13.4 Satisfies requirement `Pre-flight SHALL Check Only Selected Browser CLI` (covered by tasks 2.1, 2.2, 2.3).
+- [ ] 13.5 Satisfies requirement `Single Dispatcher Helper SHALL Route Discovery Primitives` (covered by tasks 3.1, 3.2, 4.1, 4.2, 4.3, 4.4, 4.5, 4.6).
+- [ ] 13.6 Satisfies requirement `Per-Iteration Commit Body SHALL Record Browser Mode` (covered by tasks 5.1, 5.2, 11.3).
+- [ ] 13.7 Satisfies requirement `Anti-Pattern Table SHALL NOT Forbid agent-browser for Discovery` (covered by tasks 6.1, 6.2, 11.5).
+- [ ] 13.8 Satisfies requirement `Documentation SHALL Explain When to Opt Into safari` (covered by tasks 7.2, 8.1, 8.2, 10.1, 11.5).
+- [ ] 13.9 Implements design decision `Default browser: agent` (covered by tasks 1.2, 11.1).
+- [ ] 13.10 Implements design decision `Dispatcher: helper function (Option A)` (covered by tasks 3.1, 3.2, 4.1, 4.2, 4.3, 4.4, 4.5, 4.6).
+- [ ] 13.11 Implements design decision `Selection precedence: flag > env > static default` (covered by tasks 1.1, 1.2, 1.3).
+- [ ] 13.12 Implements design decision `Pre-flight: mode-specific CLI presence check` (covered by tasks 2.1, 2.2, 2.3).
+- [ ] 13.13 Implements design decision "Audit trail: per-iteration commit body emits `BROWSER=<mode>`" (covered by tasks 5.1, 5.2, 11.3).
+- [ ] 13.14 Implements design decision `Anti-pattern table entry removed, not qualified` (covered by tasks 6.1, 6.2, 11.5).

--- a/plugins/r-shiny-debugger/.claude-plugin/plugin.json
+++ b/plugins/r-shiny-debugger/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "r-shiny-debugger",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "功能測試導向的 R Shiny App Debug 工具，整合 agent-browser（前端）與 R console（後端）+ shiny-adaptive-walk 自我收斂測試 loop",
   "author": {
     "name": "Che Cheng"

--- a/plugins/r-shiny-debugger/CHANGELOG.md
+++ b/plugins/r-shiny-debugger/CHANGELOG.md
@@ -11,6 +11,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-05-13
+
+### Changed
+- **BREAKING**: Default discovery browser for `/shiny-adaptive-walk` is now `agent-browser` (headless Chromium) instead of `safari-browser`. Existing invocations without `--browser` flag now run headless. Pass `--browser safari` (or set `SHINY_ADAPTIVE_BROWSER=safari`) to preserve the previous visible-Safari behavior. Rationale: both engines render real DOM; safari's only unique value is live visibility, which costs nothing to opt into when needed and saves multi-hour unattended runs from per-iter Safari startup, user-profile drift, and tab-focus contention. Refs PsychQuant/psychquant-claude-plugins#77 + spectra change `adaptive-walk-agent-browser-default`.
+- Anti-pattern table entry `Use agent-browser for discovery walk → wrong` removed. Using `agent-browser` for discovery is now the recommended default; using `safari-browser` is the opt-in path.
+- Troubleshooting section restructured: separate `safari-browser missing` (only matters when `--browser safari` is opted into) and `agent-browser missing` (default-path failure mode) subsections.
+- `08-shiny-testing.md` narrow exception clause cross-reference updated to note safari is opt-in via `--browser safari`; clause text itself remains accurate.
+
+### Added
+- `--browser=safari|agent` flag and `SHINY_ADAPTIVE_BROWSER` env var. Precedence: flag > env var > static default (`agent`). Invalid values abort Step 0 pre-flight with a message naming the accepted set.
+- `browser_cmd()` shell helper dispatching the five discovery primitives (open / snapshot / click / fill / screenshot) to the selected CLI. Single source of truth — Step 3a contains no direct `safari-browser` / `agent-browser` invocations.
+- Per-iteration commit body now records `BROWSER=<safari|agent>` audit-trail line for traceability.
+- New documentation section `### When to opt into --browser safari` covering live-demo / teaching / in-the-moment debugging scenarios.
+
+### Verified (per spectra change ACs)
+- Phase 1 contract primitive tests (`test_contract_primitives.R`) pass.
+- Phase 2 walker tests (`test_smoke_lite_walker.R`) pass.
+- `grep "Use agent-browser for discovery walk"` against the skill markdown returns 0 hits (AC5).
+- `grep "When to opt into"` returns multiple hits (AC6).
+
 ## [1.1.0] - 2026-05-13
 
 ### Added

--- a/plugins/r-shiny-debugger/README.md
+++ b/plugins/r-shiny-debugger/README.md
@@ -22,12 +22,13 @@ R Shiny App debug + adaptive testing tools。
 ## 前置需求
 
 ```bash
-# agent-browser (本地 dev default)
+# agent-browser (default for both /shiny-debug and /shiny-adaptive-walk discovery)
 npm install -g agent-browser
 agent-browser install
 
-# safari-browser (僅 adaptive-walk discovery phase 需要,macOS only)
+# safari-browser (opt-in for /shiny-adaptive-walk --browser safari, macOS only)
 # 安裝路徑見 https://github.com/...
+# 平常不需要;只在想看 adaptive-walk loop 即時跑(教學 / live demo / 視覺 debug)時才裝。
 
 # R + Shiny
 # 確保已安裝 R 和 shiny 套件
@@ -43,8 +44,14 @@ agent-browser install
 /shiny-debug 上傳 CSV 後圖表會更新
 
 # Adaptive testing loop(需要 spectra change adaptive-dashboard-test-loop merged)
-/shiny-adaptive-walk QEF_DESIGN
+/shiny-adaptive-walk QEF_DESIGN                  # default: agent-browser (headless)
+/shiny-adaptive-walk QEF_DESIGN --browser safari # opt-in: visible Safari for live watch
 /shiny-adaptive-walk D_RACING --budget 50 --max-iter 3
+
+# Browser mode rationale: default is headless agent-browser (faster, reproducible,
+# no macOS Safari tab-focus contention). --browser safari is opt-in for live demo /
+# teaching / in-the-moment visual debugging. See shiny-adaptive-walk.md
+# "When to opt into --browser safari" for details.
 ```
 
 ## Tool 對比

--- a/plugins/r-shiny-debugger/commands/shiny-adaptive-walk.md
+++ b/plugins/r-shiny-debugger/commands/shiny-adaptive-walk.md
@@ -1,13 +1,13 @@
 ---
-description: Self-converging adaptive walker for MP165 dashboard testing — discovers defects via safari-browser + LLM judge, auto-mutates test infra, files real bugs as /idd-issue. Spectra: adaptive-dashboard-test-loop (#653)
-argument-hint: <COMPANY> [--budget N] [--max-iter N] [--no-pr]
+description: Self-converging adaptive walker for MP165 dashboard testing — discovers defects via agent-browser (or opt-in safari-browser) + LLM judge, auto-mutates test infra, files real bugs as /idd-issue. Spectra: adaptive-dashboard-test-loop (#653) + adaptive-walk-agent-browser-default
+argument-hint: <COMPANY> [--budget N] [--max-iter N] [--no-pr] [--browser=safari|agent]
 ---
 
 # Shiny Adaptive Walk
 
 Self-converging test-builder loop for MP165 dashboard rendering acceptance. Each iteration:
 
-1. Walks the company dashboard via **safari-browser** (visible to user, real renderer = ground truth)
+1. Walks the company dashboard via **agent-browser** by default (headless Chromium — fast, stable, reproducible). Opt into visible **safari-browser** via `--browser safari` for live-watch scenarios.
 2. LLM judges each rendered screenshot for defects
 3. Bifurcates per defect:
    - **test_infra_gap** → skill auto-mutates `qef_design.yaml` / `contracts.R` / `run_smoke_lite.R`
@@ -20,7 +20,8 @@ Refs: spectra change `adaptive-dashboard-test-loop` (issue #653) / sister of `/s
 ## 使用方式
 
 ```
-/shiny-adaptive-walk QEF_DESIGN                    # default config
+/shiny-adaptive-walk QEF_DESIGN                    # default config (browser=agent)
+/shiny-adaptive-walk QEF_DESIGN --browser safari   # opt into visible Safari (live watch)
 /shiny-adaptive-walk QEF_DESIGN --budget 50        # cap LLM calls at 50
 /shiny-adaptive-walk QEF_DESIGN --max-iter 3       # cap iterations at 3 (default 5)
 /shiny-adaptive-walk QEF_DESIGN --no-pr            # don't open PR after converge
@@ -32,8 +33,8 @@ Required argument: `<COMPANY>` matching `app_config.yaml` company code (QEF_DESI
 
 | Rule | Detail |
 |------|--------|
-| **Visible discovery** | safari-browser (real macOS Safari) — user can watch each iter. Per principle `08-shiny-testing.md` narrow exception clause for adaptive-walker. |
-| **Mechanical regression** | agent-browser (headless Chromium) — confirms mutations don't break existing tests + new contracts catch defects. |
+| **Discovery walk** | Default `agent-browser` (headless Chromium) — fast, reproducible, no tab-focus contention. Opt into `safari-browser` via `--browser safari` for live observation; see "When to opt into `--browser safari`" below. Both engines render real DOM; `08-shiny-testing.md` narrow exception clause covers the opt-in safari path. |
+| **Mechanical regression** | `agent-browser` (headless Chromium) — confirms mutations don't break existing tests + new contracts catch defects. Independent of the discovery `--browser` setting. |
 | **Mutation boundary** | Skill CAN edit test infra (`98_test/e2e/**`, `23_deployment/dashboard_presence_gate.R`, `04_utils/fn_debug_mode.R`). Skill MUST NOT touch production code (`10_rshinyapp_components/`, `16_derivations/`, `04_utils/fn_analysis_*.R`, `update_scripts/ETL/`, `update_scripts/DRV/`) → files `/idd-issue` instead. |
 | **Atomic per-iter commit** | Each iteration ships as ONE commit `iter-N: <summary> (refs <#issue>)`. If post-mutation tests fail, `git reset --hard HEAD~1` reverts the iter. |
 | **LLM budget cap** | `MP165_ADAPTIVE_BUDGET=100` env var (default 100 calls per session). Short-circuit DIMINISHING when exhausted. |
@@ -47,9 +48,20 @@ Required argument: `<COMPANY>` matching `app_config.yaml` company code (QEF_DESI
 ### Step 0: Pre-flight checks
 
 ```bash
-# Required tools
-which safari-browser || abort "safari-browser CLI required (macOS only). See $L4_ENT/.../08-shiny-testing.md Live URL section"
-which agent-browser  || abort "agent-browser CLI required. npm install -g agent-browser && agent-browser install"
+# Browser selection — flag overrides env var overrides static `agent` default.
+# BROWSER_FLAG is set by the flag-parsing pass below (empty if --browser not given).
+BROWSER="${BROWSER_FLAG:-${SHINY_ADAPTIVE_BROWSER:-agent}}"
+case "$BROWSER" in
+  safari|agent) ;;
+  *) abort "--browser must be one of: safari, agent (got: $BROWSER)" ;;
+esac
+
+# Required tools — only the selected browser's CLI is required.
+if [ "$BROWSER" = "safari" ]; then
+  which safari-browser || abort "safari-browser CLI required for --browser safari (macOS only). Pass --browser agent to switch, or install safari-browser. See $L4_ENT/.../08-shiny-testing.md Live URL section"
+else
+  which agent-browser  || abort "agent-browser CLI required for default browser mode. npm install -g agent-browser && agent-browser install (or pass --browser safari if safari-browser is available)"
+fi
 which gh             || abort "gh CLI required"
 command -v Rscript   || abort "R + Rscript required"
 
@@ -64,6 +76,9 @@ Parse flags:
 - `--budget N` → override `MP165_ADAPTIVE_BUDGET` to N
 - `--max-iter N` → override `MP165_MAX_ITER` (default 5)
 - `--no-pr` → skip auto-PR at end
+- `--browser safari|agent` → override `SHINY_ADAPTIVE_BROWSER` env var (precedence: flag > env > `agent`)
+
+No tab-focus / window-count probing is performed — browser mode is determined explicitly by the precedence chain above. There is no runtime auto-fallback.
 
 ### Step 1: Working tree + branch setup
 
@@ -134,9 +149,24 @@ if [ -z "$VERDICT" ]; then
 fi
 ```
 
-#### Step 3a: Discovery walk (safari-browser, visible to user)
+#### Step 3a: Discovery walk
+
+The discovery walk uses the browser selected in Step 0 (`$BROWSER`). All five discovery primitives (`open` / `snapshot` / `click` / `fill` / `screenshot`) flow through a single dispatcher helper:
 
 ```bash
+# Single source of truth for browser dispatch.
+# safari mode appends --url "$URL_SUBSTR" for tab targeting;
+# agent mode runs headless with a single ephemeral context (no --url needed).
+# Supported subcommands: open / snapshot / click / fill / screenshot.
+browser_cmd() {
+  local subcmd="$1"; shift
+  if [ "$BROWSER" = "safari" ]; then
+    safari-browser "$subcmd" "$@" --url "$URL_SUBSTR"
+  else
+    agent-browser "$subcmd" "$@"
+  fi
+}
+
 discover_defects() {
   # 1. Start Shiny app via nohup
   cd "$COMPANY_DIR"
@@ -155,38 +185,38 @@ discover_defects() {
   URL=$(grep "Listening on" .shiny-debug/shiny.log | tail -1 | grep -oE "http://[^[:space:]]+")
   URL_SUBSTR=$(echo "$URL" | sed -E 's#https?://##; s#/$##')
 
-  # 3. Open in safari-browser with --url lock (per 08-shiny-testing.md narrow exception)
-  safari-browser open "$URL" --url "$URL_SUBSTR"
+  # 3. Open the app (safari uses --url tab targeting; agent uses headless single-context)
+  browser_cmd open "$URL"
   sleep 2
 
   # 4. Login
-  safari-browser snapshot -i --url "$URL_SUBSTR" > /tmp/snap_login.txt
+  browser_cmd snapshot -i > /tmp/snap_login.txt
   PWD_REF=$(extract_ref_from_snap /tmp/snap_login.txt "textbox.*密碼|textbox.*password")
   SUBMIT_REF=$(extract_ref_from_snap /tmp/snap_login.txt "button.*進入|button.*Login")
-  safari-browser fill "${PWD_REF:-@e1}" VIBE --url "$URL_SUBSTR"
-  safari-browser click "${SUBMIT_REF:-@e2}" --url "$URL_SUBSTR"
+  browser_cmd fill "${PWD_REF:-@e1}" VIBE
+  browser_cmd click "${SUBMIT_REF:-@e2}"
   sleep 3
 
   # 5. Walk top-level + sub-tabs, screenshot each
   SCREENSHOTS=()
   for tab in "總覽儀表板" "TagPilot" "Marketing Vital-Signs" "BrandEdge" "InsightForge 360" "報告中心"; do
-    safari-browser snapshot -i --url "$URL_SUBSTR" > "/tmp/snap_${tab}.txt"
+    browser_cmd snapshot -i > "/tmp/snap_${tab}.txt"
     TAB_REF=$(extract_ref_from_snap "/tmp/snap_${tab}.txt" "link.*${tab}")
     [ -n "$TAB_REF" ] || continue
 
-    safari-browser click "$TAB_REF" --url "$URL_SUBSTR"
+    browser_cmd click "$TAB_REF"
     sleep 2.5  # bs4Dash accordion settle
 
     # Take screenshot for top-level
-    safari-browser screenshot "/tmp/walk_iter${ITER}_${tab}.png" --url "$URL_SUBSTR"
+    browser_cmd screenshot "/tmp/walk_iter${ITER}_${tab}.png"
     SCREENSHOTS+=("/tmp/walk_iter${ITER}_${tab}.png")
 
     # Re-snap to find sub-tabs (reuse run_smoke_lite.R::.smoke_extract_sub_tab_refs)
     SUB_REFS=$(R -e "source('shared/global_scripts/98_test/e2e/run_smoke_lite.R'); cat(.smoke_extract_sub_tab_refs(snap_text, '$tab', remaining_tabs))")
     for sub_ref in $SUB_REFS; do
-      safari-browser click "$sub_ref" --url "$URL_SUBSTR"
+      browser_cmd click "$sub_ref"
       sleep 1
-      safari-browser screenshot "/tmp/walk_iter${ITER}_${tab}_${sub_ref}.png" --url "$URL_SUBSTR"
+      browser_cmd screenshot "/tmp/walk_iter${ITER}_${tab}_${sub_ref}.png"
       SCREENSHOTS+=("/tmp/walk_iter${ITER}_${tab}_${sub_ref}.png")
     done
   done
@@ -194,6 +224,8 @@ discover_defects() {
   kill -TERM "$APP_PID" 2>/dev/null
 }
 ```
+
+No literal `safari-browser` or `agent-browser` CLI invocation should appear in Step 3a outside the `browser_cmd` helper.
 
 #### Step 3b: LLM judge classification (per screenshot)
 
@@ -380,10 +412,18 @@ run_safety_gate() {
   return 0
 }
 
-# Commit + safety check + rollback if needed
+# Commit + safety check + rollback if needed.
+# Per-iter commit body carries an audit-trail line BROWSER=<safari|agent>
+# so commit history records which browser produced this iter's evidence.
 if [ -n "$(git status --porcelain)" ]; then
   git add -A
-  git commit -m "iter-$ITER: $ITER_SUMMARY (refs #$PARENT_ISSUE)" 2>&1
+  COMMIT_BODY="BROWSER=$BROWSER"
+  if [ -n "$ITER_BODY_EXTRA" ]; then
+    COMMIT_BODY="$COMMIT_BODY
+
+$ITER_BODY_EXTRA"
+  fi
+  git commit -m "iter-$ITER: $ITER_SUMMARY (refs #$PARENT_ISSUE)" -m "$COMMIT_BODY" 2>&1
 
   if ! run_safety_gate; then
     git reset --hard HEAD~1
@@ -580,7 +620,6 @@ Final yaml `# === auto-suggested ===` block contains `# (none — already covere
 | Don't | Do |
 |-------|----|
 | Edit production code (UI components, business logic) | File `/idd-issue` — skill respects bug ownership boundary |
-| Use `agent-browser` for discovery walk | Use `safari-browser` (real renderer, visible to user, principle exception) |
 | Skip per-iter regression gate | ALWAYS run test_dir + mechanical gate; auto-rollback on failure |
 | File duplicate bug issues | Compute composite signature + `gh issue list --search` before filing |
 | Run on dirty working tree | Refuse start with uncommitted changes (per Step 1) |
@@ -597,6 +636,7 @@ Final yaml `# === auto-suggested ===` block contains `# (none — already covere
 | `MP165_MAX_ITER` | 5 | Max iterations before MAX_ITER_REACHED |
 | `PARENT_ISSUE` | 653 | Issue # used in branch name + commit refs |
 | `OPEN_PR` | true | If "false", skill doesn't auto-create PR at end |
+| `SHINY_ADAPTIVE_BROWSER` | `agent` | Discovery browser. Values: `safari` or `agent`. Overridden by `--browser` flag when both are set. See "When to opt into `--browser safari`" below. |
 
 ### Flags
 
@@ -605,6 +645,21 @@ Final yaml `# === auto-suggested ===` block contains `# (none — already covere
 | `--budget N` | Override `MP165_ADAPTIVE_BUDGET` to N |
 | `--max-iter N` | Override `MP165_MAX_ITER` to N |
 | `--no-pr` | Skip auto-PR (sets `OPEN_PR=false`) |
+| `--browser safari\|agent` | Discovery browser. Default `agent`. Overrides `SHINY_ADAPTIVE_BROWSER` env var. See "When to opt into `--browser safari`" below. |
+
+### When to opt into `--browser safari`
+
+The default `agent-browser` (headless Chromium) is the right choice for almost every invocation: unattended runs, CI, multi-hour cross-company rollouts, and any case where nobody is watching the loop iterate. Headless is faster (no Safari startup or window animation per iteration), more reproducible (ephemeral context, no user-profile cookies or extensions), and immune to macOS Safari's tab-focus contention.
+
+Opt into `--browser safari` only when realtime visibility is the value:
+
+| Scenario | Why safari |
+|----------|------------|
+| Live demo / teaching | The audience needs to see the loop walk the dashboard |
+| In-the-moment debugging | You want to watch each click land in a real Safari window |
+| Visual regression spot-check | You're suspicious of an engine-specific WebKit rendering issue |
+
+If none of those apply, leave the default. Both engines render real DOM; for Shiny apps built on bs4Dash + plotly + DT there is no meaningful rendering difference. The "real renderer ground truth" framing that earlier versions of this skill carried was Safari-bias, not fact.
 
 ---
 
@@ -615,20 +670,34 @@ Final yaml `# === auto-suggested ===` block contains `# (none — already covere
 - **Parent issue**: kiki830621/ai_martech_global_scripts#653
 - **MP165 v1.2 amendment**: codifies dual-track architecture (Track A declarative `qef_design.yaml` baseline + Track B adaptive walker overlay)
 - **Prior art**: `/glue-bridge` MP102 v1.3 self-converging review pattern (CONVERGED / PLATEAUED / DIMINISHING verdicts)
-- **Principle exception**: `00_principles/.claude/rules/08-shiny-testing.md` narrow exception clause permits safari-browser on local for adaptive-walker discovery (real-renderer ground truth)
+- **Principle exception**: `00_principles/.claude/rules/08-shiny-testing.md` narrow exception clause permits safari-browser on local for adaptive-walker discovery. The clause stays accurate as written; default browser is `agent-browser` since the `adaptive-walk-agent-browser-default` change (issue PsychQuant/psychquant-claude-plugins#77), and safari is opt-in via `--browser safari`.
+- **Default browser change**: PsychQuant/psychquant-claude-plugins#77 — inverted default from safari to agent.
 - **Bug filing discipline**: IC_R011 commercial low-bar filing
 
 ---
 
 ## Troubleshooting
 
-### safari-browser missing or wrong version
+### safari-browser missing (only matters when `--browser safari` is selected)
 
 ```bash
 safari-browser --version
-# If missing: not installed (macOS only). agent-browser is fallback for local dev,
-# but skill REQUIRES safari-browser for real-renderer ground truth visibility.
 ```
+
+If `safari-browser` is missing and you passed `--browser safari` (or set `SHINY_ADAPTIVE_BROWSER=safari`), Step 0 pre-flight aborts with a message naming the missing CLI. Two ways forward:
+
+- Drop the safari opt-in: invoke without `--browser` (and unset `SHINY_ADAPTIVE_BROWSER`) — skill runs the default headless `agent-browser` path.
+- Install safari-browser: macOS-only. See `$L4_ENT/.../08-shiny-testing.md` Live URL section.
+
+If you did NOT opt into safari, this section does not apply — the default `agent-browser` path bypasses safari-browser entirely.
+
+### agent-browser missing (default path)
+
+```bash
+agent-browser --version
+```
+
+If `agent-browser` is missing and you are on the default browser mode (no `--browser` flag and no `SHINY_ADAPTIVE_BROWSER=safari`), Step 0 pre-flight aborts. Install with `npm install -g agent-browser && agent-browser install`. Most macOS dev environments already have it (used by `/shiny-debug` sister skill). Common in bare Linux CI containers.
 
 ### Branch collision
 


### PR DESCRIPTION
Implements spectra change \`adaptive-walk-agent-browser-default\` resolving #77.

## Summary

- **BREAKING**: Default discovery browser for \`/shiny-adaptive-walk\` is now \`agent-browser\` (headless Chromium) instead of \`safari-browser\`.
- New \`--browser=safari|agent\` flag + \`SHINY_ADAPTIVE_BROWSER\` env var (precedence: flag > env > default).
- New \`browser_cmd()\` shell dispatcher consolidates 14 call sites in Step 3a.
- Per-iter commit body emits \`BROWSER=\` audit-trail line.
- Anti-pattern table entry \"Use agent-browser for discovery walk\" removed.
- New \"### When to opt into --browser safari\" documentation section.
- Plugin version 1.1.0 → 1.2.0.

## Why

The \"real renderer ground truth\" framing for safari was Safari-bias, not fact. Both engines render real DOM; for Shiny apps (bs4Dash + plotly + DT) no engine-level rendering difference exists. The genuine advantage of safari is realtime visibility — worth zero for unattended multi-hour runs but valuable for live-watch scenarios. Make the common case (headless) the default; keep the visible path opt-in.

## ACs verified

- [x] AC4: Phase 1 contract primitive tests (\`test_contract_primitives.R\`) PASS
- [x] AC4: Phase 2 walker tests (\`test_smoke_lite_walker.R\`) PASS
- [x] AC5: \`grep \"Use agent-browser for discovery walk\" shiny-adaptive-walk.md\` returns 0 hits
- [x] AC6: \`grep \"When to opt into\" shiny-adaptive-walk.md\` returns multiple hits
- [ ] AC1: invoke \`/shiny-adaptive-walk QEF_DESIGN\` (no flag) confirms headless agent path — **deferred post-merge** (needs live invocation)
- [ ] AC2: invoke \`/shiny-adaptive-walk QEF_DESIGN --browser safari\` confirms visible Safari path — **deferred post-merge**

## Spectra artifacts

- \`openspec/changes/adaptive-walk-agent-browser-default/\` — proposal.md / design.md (6 decisions + alternatives) / specs/shiny-adaptive-walk-browser/spec.md (8 ADDED requirements) / tasks.md (47 sub-tasks)
- Spectra analyzer: Critical 0 / Warning 0 (after 2 iterations)
- Spectra validate: ✓

## Test plan

- [x] Local: Phase 1 + Phase 2 R unit tests pass (run from QEF_DESIGN)
- [x] Static: AC5 + AC6 grep checks pass
- [ ] Manual smoke (post-merge): \`/shiny-adaptive-walk QEF_DESIGN\` no-flag → confirm \`ps -ef | grep agent-browser\` shows running, no Safari spawn
- [ ] Manual smoke (post-merge): \`/shiny-adaptive-walk QEF_DESIGN --browser safari\` → confirm Safari window appears
- [ ] Post-merge: \`/plugin-tools:plugin-update r-shiny-debugger\` to sync marketplace

## Closes
#77